### PR TITLE
Added gitRepositoryRoot property to override git repo root location

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,18 @@ gitProperties {
 }
 ```
 
+If project root dir is not the same git repo root dir, it can be overridden like so.
+```groovy
+gitProperties {
+    gitRepositoryRoot = new File("${project.rootDir}/../..")
+}
+```
+
 > Please note that `spring-boot-actuator` expects `git.properties` to be available at certain location.
 
 This is enough to see git details via `info` endpoint of [spring-boot-actuator](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready).
- 
-Plugin is available from [Gradle Plugins repository](https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties). 
+
+Plugin is available from [Gradle Plugins repository](https://plugins.gradle.org/plugin/com.gorylenko.gradle-git-properties).
 
 ## result
 

--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -31,7 +31,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
     static class GenerateGitPropertiesTask extends DefaultTask {
         @TaskAction
         void generate() {
-            def repo = Grgit.open(dir: project.rootProject.file('.'))
+            def repo = Grgit.open(dir: project.gitProperties.gitRepositoryRoot ?: project.rootProject.file('.'))
             def dir = project.gitProperties.gitPropertiesDir ?: new File(project.buildDir, "resources/main")
             def file = new File(dir, "git.properties")
             if (!dir.exists()) {
@@ -58,4 +58,5 @@ class GitPropertiesPlugin implements Plugin<Project> {
 
 class GitPropertiesPluginExtension {
     File gitPropertiesDir
+    File gitRepositoryRoot
 }


### PR DESCRIPTION
I had a problem with a project where root gradle dir is not the same as git repo root. This should fix it.