### PR TITLE
Set inputs and outputs for up-to-date check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'org.ajoberstar:gradle-git:1.3.0'
 }
 
-version = "1.4.7"
+version = "1.4.8"
 group = "com.gorylenko.gradle-git-properties"
 
 publishing {

--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -19,6 +19,10 @@ class GitPropertiesPlugin implements Plugin<Project> {
 
         project.extensions.create("gitProperties", GitPropertiesPluginExtension)
         def task = project.tasks.create('generateGitProperties', GenerateGitPropertiesTask)
+        task.inputs.dir(new File(project.gitProperties.gitRepositoryRoot ?: project.rootProject.file('.'),".git"))
+
+        def dir = project.gitProperties.gitPropertiesDir ?: new File(project.buildDir, "resources/main")
+        task.outputs.file(new File(dir, "git.properties"))
 
         task.setGroup(BasePlugin.BUILD_GROUP)
         ensureTaskRunsOnJavaClassesTask(project, task)


### PR DESCRIPTION
Set task.inputs.dir to .git directory and set task.output.file to git.properties file.  Gradle can then check if input and output are already set up.  If so, task is not executed.