### PR TITLE
Fixed NPE. Occured when git properties are not set in build.gradle

### DIFF
--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -55,7 +55,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
                        , "git.commit.message.full" : repo.head().fullMessage
                        , "git.commit.time"         : repo.head().time.toString()]
             def props = new Properties()
-            props.putAll(map.subMap(project.gitProperties.keys))
+            props.putAll(map.subMap(keys))
             props.store(file.newWriter(), "")
         }
     }


### PR DESCRIPTION
I experienced a NPE when running the build without settings _keys_ variable in my build.gradle. _project.gitProperties.keys_ is null, _keys_ which has sensible defaults is not used.