### PR TITLE
Fixes https://github.com/n0mer/gradle-git-properties/issues/5

### DIFF
--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -29,6 +29,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
     }
 
     private static void ensureTaskRunsOnJavaClassesTask(Project project, Task task) {
+        project.plugins.apply JavaPlugin
         project.getTasks().getByName(JavaPlugin.CLASSES_TASK_NAME).dependsOn(task)
     }
 


### PR DESCRIPTION
Ensure JavaPlugin is applied to project before referencing task defined in JavaPlugin.