### PR TITLE
Adding format support for the date in git.commit.time (Issue #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Declare this in your `build.gradle`
 
 ```groovy
 plugins {
-  id "com.gorylenko.gradle-git-properties" version "1.4.11"
+  id "com.gorylenko.gradle-git-properties" version "1.4.16"
 }
 ```
 
@@ -18,6 +18,14 @@ If needed - override location of `git.properties` file like this:
 ```groovy
 gitProperties {
     gitPropertiesDir = new File("${project.rootDir}/your/custom/dir")
+}
+```
+
+If needed - use `dateFormat` and `dateFormatTimeZone` to format `git.commit.time` value (See [SimpleDateFormat](http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html) and [TimeZone](http://docs.oracle.com/javase/7/docs/api/java/util/TimeZone.html) for values)
+```groovy
+gitProperties {
+    dateformat = "yyyy-MM-dd'T'HH:mmZ"
+    dateformatTimeZone = "PST"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'org.ajoberstar:gradle-git:1.4.2'
 }
 
-version = "1.4.15"
+version = "1.4.16"
 group = "com.gorylenko.gradle-git-properties"
 
 publishing {

--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -1,5 +1,7 @@
 package com.gorylenko
 
+import java.text.SimpleDateFormat
+
 import org.ajoberstar.grgit.Grgit
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
@@ -66,12 +68,25 @@ class GitPropertiesPlugin implements Plugin<Project> {
                        , "git.commit.user.email"   : repo.head().author.email
                        , "git.commit.message.short": repo.head().shortMessage
                        , "git.commit.message.full" : repo.head().fullMessage
-                       , "git.commit.time"         : repo.head().time.toString()]
+                       , "git.commit.time"         : formatDate(repo.head().time, project.gitProperties.dateFormat, project.gitProperties.dateFormatTimeZone)]
 
             file.withWriter('UTF-8') { w ->
                 map.subMap(keys).each { key, value ->
                     w.writeLine "$key=$value"
                 }
+            }
+        }
+
+        private String formatDate(long timestamp, String dateFormat, String timezone) {
+            String date
+            if (dateFormat) {
+                def sdf = new SimpleDateFormat(dateFormat)
+                if (timezone) {
+                    sdf.setTimeZone(TimeZone.getTimeZone(timezone))
+                }
+                date = sdf.format(new Date(timestamp * 1000L))
+            } else {
+                date = timestamp.toString()
             }
         }
     }
@@ -81,4 +96,6 @@ class GitPropertiesPluginExtension {
     File gitPropertiesDir
     File gitRepositoryRoot
     List keys
+    String dateFormat
+    String dateFormatTimeZone
 }


### PR DESCRIPTION
Added two new configuration keys dateFormat and dateFormatTimeZone to allow formatting git.commit.time