### PR TITLE
Set targetCompatibility to Java 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ dependencies {
 version = "1.4.16"
 group = "com.gorylenko.gradle-git-properties"
 
+tasks.withType(GroovyCompile) {
+    targetCompatibility = JavaVersion.VERSION_1_7
+}
+
 publishing {
 
     publications {


### PR DESCRIPTION
This will make it possible to use the plugin in builds that for some reason have to run on Java 7.

Fixes issue #21 