### PR TITLE
Fixed #28 (multi line full commit message breaks properties file syntax)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ gradle-app.setting
 
 ## mac
 .DS_Store
+/bin/
+.classpath
+.project
+.settings


### PR DESCRIPTION
Using Properties to support multiple messages, also also trying to avoid writing new file if the existing file having the same content to the file would be created