### PR TITLE
Add support unicode escape as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Declare this in your `build.gradle`
 
 ```groovy
 plugins {
-  id "com.gorylenko.gradle-git-properties" version "1.4.16"
+  id "com.gorylenko.gradle-git-properties" version "1.4.18"
 }
 ```
 
@@ -33,6 +33,13 @@ If project root dir is not the same git repo root dir, it can be overridden like
 ```groovy
 gitProperties {
     gitRepositoryRoot = new File("${project.rootDir}/../..")
+}
+```
+
+If needed - use `unicodeEscape` to escape unicode characters.
+```groovy
+gitProperties {
+    unicodeEscape = true // false as default
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'org.ajoberstar:gradle-git:1.4.2'
 }
 
-version = "1.4.17"
+version = "1.4.18"
 group = "com.gorylenko.gradle-git-properties"
 
 tasks.withType(GroovyCompile) {

--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -1,5 +1,7 @@
 package com.gorylenko
 
+import groovy.json.StringEscapeUtils
+
 import java.text.SimpleDateFormat
 
 import org.ajoberstar.grgit.Grgit
@@ -15,7 +17,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 class GitPropertiesPlugin implements Plugin<Project> {
-    
+
     private static final String EXTENSION_NAME = "gitProperties"
     private static final String TASK_NAME = "generateGitProperties"
 
@@ -93,7 +95,8 @@ class GitPropertiesPlugin implements Plugin<Project> {
 
             file.withWriter(CHARSET) { w ->
                 map.subMap(keys).each { key, value ->
-                    w.writeLine "$key=$value"
+                    def convertedValue = project.gitProperties.unicodeEscape ? StringEscapeUtils.escapeJava(value) : value
+                    w.writeLine "$key=$convertedValue"
                 }
             }
         }
@@ -119,4 +122,5 @@ class GitPropertiesPluginExtension {
     List keys
     String dateFormat
     String dateFormatTimeZone
+    Boolean unicodeEscape
 }


### PR DESCRIPTION
#### Background
Java properties file requires unicode escaping for non 8859_1 characters. Current implementation just writes files with UTF-8 encoding, so non-ascii charactered in properties file can not be loaded properly. This implementation add option `unicodeEscape` for this feature.  

#### How to Use
If User specifies `unicodeEscape` as an option, all values in properties file will be written in unicode escaped characters. 
