### PR TITLE
change encoding of git.properties to ISO-8859-1

### DIFF
--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -22,7 +22,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
     private static final String GIT_PROPERTIES_FILENAME = "git.properties"
     private static final String DEFAULT_OUTPUT_DIR = "resources/main"
 
-    private static final String CHARSET = "UTF-8"
+    private static final String CHARSET = "ISO-8859-1"
 
     private static final String KEY_GIT_BRANCH = "git.branch"
     private static final String KEY_GIT_COMMIT_ID = "git.commit.id"


### PR DESCRIPTION
when reading the git.properties file, Spring uses the method java.util.Properties.load(InputStream inStream).
This method expects an InputStream with ISO-8859-1 encoding.

gradle-git-properties however stores the git.properties file with UTF-8 encoding. This will, for instance with german commit messages containing charachters like ä, ö, ü or ß, cause messed up strings.

The git.properties file should thus be written with ISO-8859-1 encoding.