### PR TITLE
Fix #26 (Allow branch name to be overridden using env vars)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,6 @@ gitProperties {
 
 > Please note that `spring-boot-actuator` expects `git.properties` to be available at certain location.
 
-In some situations, for example when you run your build under a CI tool that checks out your code in detached mode, and HEAD no longer points to a branch name, but your CI tool
-exposes the branch in an environment variable, you can explicitly set the branch name to be written into the `git.properties` file:
-```groovy
-gitProperties {
-    gitBranchName = System.getenv('BRANCH_NAME')
-}
-```
-
 This is enough to see git details via `info` endpoint of [spring-boot-actuator](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready).
 
 You can have more fine grained control of the content of 'git.properties':

--- a/src/test/groovy/com/gorylenko/GitPropertiesPluginTests.groovy
+++ b/src/test/groovy/com/gorylenko/GitPropertiesPluginTests.groovy
@@ -4,7 +4,6 @@ import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Test
 
-import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
@@ -84,29 +83,5 @@ class GitPropertiesPluginTests {
         } catch (Exception e) {
             assertNotNull(e)
         }
-    }
-
-    @Test
-    public void testGenerateWithCustomBranchName() {
-        def projectDir = new File('.')
-
-        Project project = ProjectBuilder.builder().withProjectDir(projectDir).build()
-        project.pluginManager.apply 'com.gorylenko.gradle-git-properties'
-
-        // FIXME: Didn't find any way to change `rootProject`, so just set the property.
-        project.gitProperties.gitRepositoryRoot = projectDir
-        project.gitProperties.gitBranchName = "FOO"
-
-        def task = project.tasks.generateGitProperties
-        assertTrue(task instanceof GitPropertiesPlugin.GenerateGitPropertiesTask)
-
-        task.generate()
-
-        def gitPropertiesFile = project.buildDir.getAbsolutePath() + '/resources/main/git.properties'
-
-        Properties properties = new Properties()
-        properties.load(new FileInputStream(gitPropertiesFile))
-        assertNotNull(properties.getProperty("git.branch"))
-        assertEquals("FOO", properties.getProperty("git.branch"))
     }
 }


### PR DESCRIPTION
The previous PR #47 (for issue #46) requires users to specify git branch name manually while the issue #46 clearly mentioned that the value should be detected automatically from system environment variables (like maven-git-commit-id-plugin). This PR is to replace PR #47 and make this plugin to be consistent to maven-git-commit-id plugin.