### PR TITLE
Fix issue #57 (All properties are generated when keys=[])

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ gitProperties {
 
 This is enough to see git details via `info` endpoint of [spring-boot-actuator](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready).
 
-You can have more fine grained control of the content of 'git.properties':
+By default, all available git properties (which are supported by the plugin) will be generated. You can have more fine grained control of the content of 'git.properties':
 ```groovy
 gitProperties {
     keys = ['git.branch','git.commit.id','git.commit.time']

--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -38,7 +38,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
             KEY_GIT_COMMIT_ID, KEY_GIT_COMMIT_ID_ABBREVIATED,
             KEY_GIT_COMMIT_USER_NAME, KEY_GIT_COMMIT_USER_EMAIL,
             KEY_GIT_COMMIT_SHORT_MESSAGE, KEY_GIT_COMMIT_FULL_MESSAGE,
-            KEY_GIT_COMMIT_TIME, KEY_GIT_COMMIT_ID_DESCRIBE,
+            KEY_GIT_COMMIT_ID_DESCRIBE,
             KEY_GIT_COMMIT_TIME, KEY_GIT_DIRTY
     ]
 
@@ -79,7 +79,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
             def repo = Grgit.open(dir: repositoryGitDir)
             def dir = project.gitProperties.gitPropertiesDir ?: new File(project.buildDir, DEFAULT_OUTPUT_DIR)
             def file = new File(dir, GIT_PROPERTIES_FILENAME)
-            def keys = project.gitProperties.keys ?: KEY_ALL
+            def keys = project.gitProperties.keys
 
             def map = [(KEY_GIT_BRANCH)                 : { determineBranchName(repo) }
                        , (KEY_GIT_COMMIT_ID)            : { repo.head().id }
@@ -179,7 +179,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
 class GitPropertiesPluginExtension {
     File gitPropertiesDir
     File gitRepositoryRoot
-    List keys
+    List keys = GitPropertiesPlugin.KEY_ALL.toList()
     Map<String, Object> customProperties = new HashMap<String, Object>()
     String dateFormat
     String dateFormatTimeZone


### PR DESCRIPTION
Fix issue #57 (All properties are generated when configuring gitProperties { keys = [] })
Also remove the redundant key KEY_GIT_COMMIT_TIME in KEY_ALL