### PR TITLE
Upgrade target compatibility to Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ version = "1.4.21"
 group = "com.gorylenko.gradle-git-properties"
 
 tasks.withType(GroovyCompile) {
-    targetCompatibility = JavaVersion.VERSION_1_7
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 publishing {


### PR DESCRIPTION
Now the plugin requires Java 8 since 9b8fb3363ebf740aba64459c767e5aa3add8aab1