### PR TITLE
Configure gradle build scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+install: true
+script:
+  - ./gradlew --scan build

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,15 @@ buildscript {
     }
 }
 
+plugins {
+    id 'com.gradle.build-scan' version '1.16'
+}
+
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}
+
 apply plugin: "com.gradle.plugin-publish"
 apply plugin: "com.gorylenko.gradle-git-properties"
 apply plugin: 'maven-publish'


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.