### PR TITLE
Update grgit-core dependency version to 4.0.1 from 3.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'org.ajoberstar.grgit:grgit-core:3.1.1'
+    compile 'org.ajoberstar.grgit:grgit-core:4.0.1'
     // for debugging
     //compile 'org.gradle:gradle-language-jvm:5.6.2'
     //compile 'org.gradle:gradle-language-java:5.6.2'
@@ -44,7 +44,7 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
-version = "2.2.0"
+version = "2.2.1"
 group = "com.gorylenko.gradle-git-properties"
 
 gitProperties {


### PR DESCRIPTION
I use `gradle-git-properties` in a project of mine, and I ran into an issue that can only be solved by updating the `grgit-core` dependency version to `6.0.1`.

The issue is that version `3.1.1` of `grgit-core` currently depends on an outdated version of `org.eclipse.jgit`, which is breaking my project's build with the following message:

    Execution failed for task ':generateGitProperties'.
    > No signature of method: org.eclipse.jgit.api.DescribeCommand.setTags() is applicable for argument types: (Boolean) values: [false]
      Possible solutions: setLong(boolean), setTarget(java.lang.String), setTarget(org.eclipse.jgit.lib.ObjectId), getClass(), 
      equals(java.lang.Object)
 
I believe that this upgrade will fix my issue, as well as possibly #140

Thanks!