### PR TITLE
Update grgit-core to 4.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.publish:plugin-publish-plugin:0.12.0"
-        classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.2.2"
+        classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:2.2.3"
     }
 }
 
@@ -35,7 +35,7 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'org.ajoberstar.grgit:grgit-core:3.1.1'
+    compile 'org.ajoberstar.grgit:grgit-core:4.1.0'
     // for debugging
     //compile 'org.gradle:gradle-language-jvm:5.6.2'
     //compile 'org.gradle:gradle-language-java:5.6.2'


### PR DESCRIPTION
I am updating the `grgit-core` dependency to `4.1.0` to avoid the "`close() called when useCnt is already zero for Repository[......./.git]`" warning when the task `generateGitProperties` is called.

---

See ajoberstar/grgit#305