### PR TITLE
avoid eager configuration of task

### DIFF
--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -24,7 +24,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
     void apply(Project project) {
 
         project.extensions.create(EXTENSION_NAME, GitPropertiesPluginExtension)
-        def task = project.tasks.create(GenerateGitPropertiesTask.TASK_NAME, GenerateGitPropertiesTask)
+        def task = project.tasks.register(GenerateGitPropertiesTask.TASK_NAME, GenerateGitPropertiesTask)
 
         task.setGroup(BasePlugin.BUILD_GROUP)
         ensureTaskRunsOnJavaClassesTask(project, task)
@@ -35,7 +35,7 @@ class GitPropertiesPlugin implements Plugin<Project> {
         // see https://guides.gradle.org/implementing-gradle-plugins/#reacting_to_plugins
         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {
             public void execute(JavaPlugin javaPlugin) {
-                project.getTasks().getByName(JavaPlugin.CLASSES_TASK_NAME).dependsOn(task)
+                project.getTasks().named(JavaPlugin.CLASSES_TASK_NAME).dependsOn(task)
                 project.gradle.projectsEvaluated { // Defer to end of the step to make sure extension config values are set
                     task.onJavaPluginAvailable()
                 }


### PR DESCRIPTION
in a multi-project build with a bunch of subprojects, this plugin is eating up a second or two of config time when it really doesn't need to. Also, gradle considers usage of these eager functions as something to generally be avoided.

> The `create(…​)` API eagerly creates and configures tasks when it is called and should be avoided.

https://docs.gradle.org/current/userguide/task_configuration_avoidance.html