### PR TITLE
Throw GradleException if .git directory is missing

### DIFF
--- a/src/main/groovy/com/gorylenko/GenerateGitPropertiesTask.groovy
+++ b/src/main/groovy/com/gorylenko/GenerateGitPropertiesTask.groovy
@@ -1,5 +1,6 @@
 package com.gorylenko
 
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -66,6 +67,11 @@ class GenerateGitPropertiesTask extends DefaultTask {
         }
 
         File dotGitDirectory = getDotGitDirectory(project)
+
+        if (dotGitDirectory == null) {
+            throw new GradleException("No Git repository found.")
+        }
+
         logger.info("dotGitDirectory = [${dotGitDirectory?.absolutePath}]")
 
 

--- a/src/test/groovy/com/gorylenko/GitPropertiesPluginTests.groovy
+++ b/src/test/groovy/com/gorylenko/GitPropertiesPluginTests.groovy
@@ -1,14 +1,17 @@
 package com.gorylenko
 
+import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
+import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertFalse
 import static org.junit.Assert.assertNotNull
 import static org.junit.Assert.assertTrue
+import static org.junit.Assert.fail
 
 class GitPropertiesPluginTests {
 
@@ -28,14 +31,14 @@ class GitPropertiesPluginTests {
     public void testGenerate() {
 
         // copy this project dir to temp directory (including git repository folder)
-        new AntBuilder().copy(todir: projectDir) { fileset(dir : ".") }
+        new AntBuilder().copy(todir: projectDir) { fileset(dir : ".", defaultexcludes: false) }
 
         Project project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.pluginManager.apply 'com.gorylenko.gradle-git-properties'
 
         // FIXME: Didn't find any way to change `rootProject`, so just set the property.
         GitPropertiesPluginExtension ext = project.getExtensions().getByName("gitProperties")
-        ext.dotGitDirectory = new File('.git')
+        ext.dotGitDirectory = new File(projectDir, '.git')
 
         def task = project.tasks.generateGitProperties
         assertTrue(task instanceof GenerateGitPropertiesTask)
@@ -87,9 +90,10 @@ class GitPropertiesPluginTests {
 
         try {
             task.generate()
-            fail('should have gotten a RepositoryNotFoundException')
+            fail('should have gotten a GradleException')
         } catch (Exception e) {
-            assertNotNull(e)
+            assertEquals(GradleException, e.class)
+            assertEquals("No Git repository found.", e.message)
         }
     }
 }


### PR DESCRIPTION
`GitPropertiesPluginTests#testGenerateWithMissingGitRepoShouldFail` incorrectly asserted that every exception would be a `RepositoryNotFoundException` while in reality the thrown exception was about `Assert.fail()` not being imported and no such method could be found.

While fixing the test, I learned that JGit wouldn't throw a `RepositoryNotFoundException` in every case but happily walk up the directory tree until it found a `.git` directory starting from the current working directory with `findGitDir()` (see [`BaseRepositoryBuilder#findGitDir()`](https://archive.eclipse.org/jgit/site/3.7.0.201502260915-r/org.eclipse.jgit/apidocs/org/eclipse/jgit/lib/BaseRepositoryBuilder.html#findGitDir()), [`BaseRepositoryBuilder#findGitDir(java.io.File)`](https://archive.eclipse.org/jgit/site/3.7.0.201502260915-r/org.eclipse.jgit/apidocs/org/eclipse/jgit/lib/BaseRepositoryBuilder.html#findGitDir(java.io.File))).

Instead of relying on this behavior, `GenerateGitPropertiesTask#getGeneratedProperties()` will now throw a `GradleException` if `dotGitDirectory` is `null` to get the expected behavior.

As an alternative, `GitPropertiesPluginTests#testGenerateWithMissingGitRepoShouldFail` could be removed if the default behavior of JGit (walking up the directory tree until a `.git` directory was found, starting from the current working directory) is the desired behavior.