### PR TITLE
Add support for configuration cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ git.remote.origin.url
 git.tags
 git.total.commit.count
 ```
-You can have more fine-grained control of the content of `git.properties using `keys`:
+You can have more fine-grained control of the content of `git.properties` using `keys`:
 
 ```groovy
 gitProperties {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Declare this in your `build.gradle`
 
 ```groovy
 plugins {
-  id "com.gorylenko.gradle-git-properties" version "2.2.4"
+  id "com.gorylenko.gradle-git-properties" version "2.3.0"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ plugins {
 }
 ```
 
-A `git.properties file will be generated when building Java-based projects (the plugin will configure any existing `classes` task to depend on `generateGitProperties` task - which is responsible for generated `git.properties` file). For non-Java projects, `generateGitProperties` task must be executed explicitly to generate `git.properties` file. The git repository for the project will be used.
+A `git.properties` file will be generated when building Java-based projects (the plugin will configure any existing `classes` task to depend on `generateGitProperties` task - which is responsible for generated `git.properties` file). For non-Java projects, `generateGitProperties` task must be executed explicitly to generate `git.properties` file. The git repository for the project will be used.
 
 Spring Boot specific info: This is enough to see git details via `info` endpoint of [spring-boot-actuator](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready).
 
@@ -69,7 +69,7 @@ Note: Kotlin DSL syntax
 configure<com.gorylenko.GitPropertiesPluginExtension> { dateFormat = "yyyy-MM-dd'T'HH:mmZ" }
 ```
 
-If needed - `use `branch` to override git branch name (when it cannot be detected correctly from environment variables/working directory)
+If needed - use `branch` to override git branch name (when it cannot be detected correctly from environment variables/working directory)
 
 ```groovy
 gitProperties {
@@ -252,7 +252,7 @@ task printGitProperties(dependsOn: 'generateGitProperties') { // make sure gener
 }
 ```
 
-Below is another example about using generated properties for `MANIFEST.MF of a Spring Boot webapp (similar can be done for non Spring apps). Note the usage of ``GString lazy evaluation to delay evaluating `project.ext.gitProps['git.commit.id.abbrev']` until ``MANIFEST.MF is created. Because `generateGitProperties` task will always execute automatically before any `classes` task (in Java projects), no `dependsOn` is needed for `bootJar` task.
+Below is another example about using generated properties for `MANIFEST.MF` of a Spring Boot webapp (similar can be done for non Spring apps). Note the usage of `GString` lazy evaluation to delay evaluating `project.ext.gitProps['git.commit.id.abbrev']` until `MANIFEST.MF` is created. Because `generateGitProperties` task will always execute automatically before any `classes` task (in Java projects), no `dependsOn` is needed for `bootJar` task.
 
 ```groovy
 gitProperties {

--- a/README.md
+++ b/README.md
@@ -7,10 +7,19 @@ Idea - @lievendoclo, originally published in article [Spring Boot's info endpoin
 
 [![Build Status](https://travis-ci.org/n0mer/gradle-git-properties.svg?branch=master)](https://travis-ci.org/n0mer/gradle-git-properties)
 
+## compatibility matrix
+
+This Gradle plugin is compatible with the following versions of Gradle:
+
+| Plugin version | Min. Gradle version |
+| -------------- | ------------------- |
+| 2.3.0          | 5.1                 |
+| 2.2.4          | 4.x                 |
+
 ## notes
 * Plugin requires Java 8+
-* If git.properties is missing on gradle 5.1.x and 5.2.x [Issue 128](https://github.com/n0mer/gradle-git-properties/issues/128), use gitPropertiesResourceDir to config a diffrent output directory 
-* Since gradle-git-properties v2.x, we requires jgit 5.x, this might cause some issues if you have other gradle plugin which uses jgit 1.4.x. In that case, you can use gradle-git-properties v1.5.x (instead of 2.x) which uses jgit 1.4.x. See [Issue 133](https://github.com/n0mer/gradle-git-properties/issues/133) for more info about this plugin's dependencies
+* If `git.properties` is missing on Gradle 5.1.x and 5.2.x [Issue 128](https://github.com/n0mer/gradle-git-properties/issues/128), use `gitPropertiesResourceDir` to config a different output directory 
+* Since gradle-git-properties v2.x, we require JGit 5.x, this might cause some issues if you have other gradle plugin which uses JGit 1.4.x. In that case, you can use gradle-git-properties v1.5.x (instead of 2.x) which uses JGit 1.4.x. See [Issue 133](https://github.com/n0mer/gradle-git-properties/issues/133) for more info about this plugin's dependencies
 
 ## usage
 
@@ -22,7 +31,7 @@ plugins {
 }
 ```
 
-A git.properties file will be generated when building Java-based projects (the plugin will configure any existing `classes` task to depend on `generateGitProperties` task - which is responsible for generated git.properties file). For non-Java projects, `generateGitProperties` task must be executed explicitly to generate git.properties file. The git repository for the project will be used.
+A `git.properties file will be generated when building Java-based projects (the plugin will configure any existing `classes` task to depend on `generateGitProperties` task - which is responsible for generated `git.properties` file). For non-Java projects, `generateGitProperties` task must be executed explicitly to generate `git.properties` file. The git repository for the project will be used.
 
 Spring Boot specific info: This is enough to see git details via `info` endpoint of [spring-boot-actuator](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready).
 
@@ -60,7 +69,7 @@ Note: Kotlin DSL syntax
 configure<com.gorylenko.GitPropertiesPluginExtension> { dateFormat = "yyyy-MM-dd'T'HH:mmZ" }
 ```
 
-If needed - use `branch` to override git branch name (when it cannot be detected correctly from environment variables/working directory)
+If needed - `use `branch` to override git branch name (when it cannot be detected correctly from environment variables/working directory)
 
 ```groovy
 gitProperties {
@@ -92,7 +101,7 @@ git.remote.origin.url
 git.tags
 git.total.commit.count
 ```
-You can have more fine grained control of the content of 'git.properties' using `keys`:
+You can have more fine-grained control of the content of `git.properties using `keys`:
 
 ```groovy
 gitProperties {
@@ -110,7 +119,7 @@ gitProperties {
 }
 ```
 
-You can also replace standard properties using `customProperty`. In the below example, the logic `it.describe(tags: true)` will replace plugin's logic which using `describe(tags: false)`
+You can also replace standard properties using `customProperty`. In the below example, the logic `it.describe(tags: true)` will replace the plugin's logic which using `describe(tags: false)`
 
 ```groovy
 gitProperties {
@@ -122,10 +131,11 @@ gitProperties {
 ```
 
 
-> Spring Boot specific info: By default, the `info` endpoint exposes only `git.branch`, `git.commit.id`, and `git.commit.time` properties (even then there are more in your git.properties).
+> Spring Boot specific info: By default, the `info` endpoint exposes only `git.branch`, `git.commit.id`, and `git.commit.time` properties (even then there are more in your `git.properties`).
 > In order to expose all available properties, set the "management.info.git.mode" property to "full" per [the Spring Boot documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html#production-ready-application-info-git), e.g. in application.properties:
-
-> `management.info.git.mode=full`
+> ```
+> management.info.git.mode=full
+> ```
 
 
 The `.git` directory for the project should be detected automatically, otherwise it can be specified manually using `dotGitDirectory`:
@@ -144,7 +154,7 @@ gitProperties {
 }
 ```
 
-To skip plugin execution completely, configure task's `enabled` property:
+To skip plugin execution completely, configure the `enabled` property:
 
 ```groovy
 tasks.withType(com.gorylenko.GenerateGitPropertiesTask).all { enabled = false }
@@ -152,7 +162,7 @@ tasks.withType(com.gorylenko.GenerateGitPropertiesTask).all { enabled = false }
 
 ## result from `info` endpoint (if used with Spring Boot apps)
 
-When using with Spring Boot: This is raw `JSON` from `info` endpoint (with management.info.git.mode=simple or not configured):
+When using with Spring Boot: This is raw `JSON` from `info` endpoint (with `management.info.git.mode=simple` or not configured):
 
 ```json
 {
@@ -166,7 +176,7 @@ When using with Spring Boot: This is raw `JSON` from `info` endpoint (with manag
 }
 ```
 
-This is raw `JSON` from `info` endpoint (with management.info.git.mode=full):
+This is raw `JSON` from `info` endpoint (with `management.info.git.mode=full`):
 
 ```json
 {
@@ -222,7 +232,10 @@ This is raw `JSON` from `info` endpoint (with management.info.git.mode=full):
 
 ### other usages
 
-This plugin can also be used for other purposes (by configuring `extProperty` to keep generated properties and accessing the properties from `project.ext`). Note that the git.properties file is always generated and currently there is no option to disable it. Also please make sure that the `generateGitProperties` task is executed before accessing the generated properties.
+This plugin can also be used for other purposes (by configuring `extProperty` to keep generated properties and accessing the properties from `project.ext`).
+
+Note that the `git.properties` file is always generated and currently there is no option to disable it.
+Please also make sure that the `generateGitProperties` task is executed before accessing the generated properties.
 
 In the below example, `printGitProperties` will print `git.commit.id.abbrev` property when it is executed:
 
@@ -239,7 +252,7 @@ task printGitProperties(dependsOn: 'generateGitProperties') { // make sure gener
 }
 ```
 
-Below is another example about using generated properties for MANIFEST.MF of a Spring Boot webapp (similar can be done for non Spring apps). Note the usage of GString lazy evaluation to delay evaluating `project.ext.gitProps['git.commit.id.abbrev']` until MANIFEST.MF is created. Because `generateGitProperties` task will always execute automatically before any `classes` task (in Java projects), no `dependsOn` is needed for `bootJar` task.
+Below is another example about using generated properties for `MANIFEST.MF of a Spring Boot webapp (similar can be done for non Spring apps). Note the usage of ``GString lazy evaluation to delay evaluating `project.ext.gitProps['git.commit.id.abbrev']` until ``MANIFEST.MF is created. Because `generateGitProperties` task will always execute automatically before any `classes` task (in Java projects), no `dependsOn` is needed for `bootJar` task.
 
 ```groovy
 gitProperties {
@@ -255,13 +268,14 @@ bootJar {
   }
 }
 ```
-Note: Kotlin DSL syntax (similar to above GString example)
+
+Note: Kotlin DSL syntax (similar to above `GString` example)
 ```kotlin
-...
+// [...]
 put("Implementation-Version", object {
   override fun toString():String = (project.extra["gitProps"] as Map<String, String>)["git.commit.id"]!!
 })
-...
+// [...]
 ```
 ## license
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testImplementation gradleTestKit()
 }
 
-version = "2.2.4"
+version = "2.3.0"
 group = "com.gorylenko.gradle-git-properties"
 
 gitProperties {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'groovy'
     id 'maven-publish'
+    id 'java-gradle-plugin'
     id "com.gradle.plugin-publish" version "0.13.0"
     id "com.gorylenko.gradle-git-properties" version "2.2.4"
 }
@@ -30,6 +31,7 @@ dependencies {
 
 
     testImplementation 'junit:junit:4.12'
+    testImplementation gradleTestKit()
 }
 
 version = "2.2.4"

--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -7,12 +7,15 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
 
 
 class GitPropertiesPlugin implements Plugin<Project> {
@@ -23,21 +26,22 @@ class GitPropertiesPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
 
-        project.extensions.create(EXTENSION_NAME, GitPropertiesPluginExtension)
-        def task = project.tasks.create(GenerateGitPropertiesTask.TASK_NAME, GenerateGitPropertiesTask)
+        project.extensions.create(EXTENSION_NAME, GitPropertiesPluginExtension, project)
+        def task = project.tasks.register(GenerateGitPropertiesTask.TASK_NAME, GenerateGitPropertiesTask) {
+            it.setGroup(BasePlugin.BUILD_GROUP)
+        }
 
-        task.setGroup(BasePlugin.BUILD_GROUP)
         ensureTaskRunsOnJavaClassesTask(project, task)
     }
 
-    private static void ensureTaskRunsOnJavaClassesTask(Project project, Task task) {
+    private static void ensureTaskRunsOnJavaClassesTask(Project project, TaskProvider<GenerateGitPropertiesTask> task) {
         // if Java plugin is applied, execute this task automatically when "classes" task is executed
         // see https://guides.gradle.org/implementing-gradle-plugins/#reacting_to_plugins
         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {
             public void execute(JavaPlugin javaPlugin) {
                 project.getTasks().getByName(JavaPlugin.CLASSES_TASK_NAME).dependsOn(task)
                 project.gradle.projectsEvaluated { // Defer to end of the step to make sure extension config values are set
-                    task.onJavaPluginAvailable()
+                    task.get().onJavaPluginAvailable()
                 }
             }
         })
@@ -46,10 +50,13 @@ class GitPropertiesPlugin implements Plugin<Project> {
 
 @ToString(includeNames=true)
 class GitPropertiesPluginExtension {
-    def gitPropertiesDir
-    def gitPropertiesResourceDir
+    @InputDirectory
+    final DirectoryProperty gitPropertiesDir
+    @InputDirectory
+    final DirectoryProperty gitPropertiesResourceDir
     String gitPropertiesName = "git.properties"
-    def dotGitDirectory
+    @InputDirectory
+    final DirectoryProperty dotGitDirectory
     List keys = GitProperties.standardProperties
     Map<String, Object> customProperties = [:]
     String dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
@@ -58,6 +65,12 @@ class GitPropertiesPluginExtension {
     String extProperty
     boolean failOnNoGitDirectory = true
     boolean force
+
+    GitPropertiesPluginExtension(Project project) {
+        gitPropertiesDir = project.objects.directoryProperty()
+        gitPropertiesResourceDir = project.objects.directoryProperty()
+        dotGitDirectory = project.objects.directoryProperty().convention(project.layout.projectDirectory.dir(".git"))
+    }
 
     void customProperty(String name, Object value) {
         customProperties.put(name, value)

--- a/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
+++ b/src/main/groovy/com/gorylenko/GitPropertiesPlugin.groovy
@@ -39,9 +39,13 @@ class GitPropertiesPlugin implements Plugin<Project> {
         // see https://guides.gradle.org/implementing-gradle-plugins/#reacting_to_plugins
         project.getPlugins().withType(JavaPlugin.class, new Action<JavaPlugin>() {
             public void execute(JavaPlugin javaPlugin) {
-                project.getTasks().getByName(JavaPlugin.CLASSES_TASK_NAME).dependsOn(task)
-                project.gradle.projectsEvaluated { // Defer to end of the step to make sure extension config values are set
-                    task.get().onJavaPluginAvailable()
+                project.tasks.named(JavaPlugin.CLASSES_TASK_NAME).configure {
+                    dependsOn(task)
+
+                    project.gradle.projectsEvaluated {
+                        // Defer to end of the step to make sure extension config values are set
+                        task.get().onJavaPluginAvailable()
+                    }
                 }
             }
         })

--- a/src/test/groovy/com/gorylenko/BackwardCompatibilityFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/BackwardCompatibilityFunctionalTest.groovy
@@ -3,6 +3,7 @@ package com.gorylenko
 import com.gorylenko.properties.GitRepositoryBuilder
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -19,34 +20,38 @@ public class BackwardCompatibilityFunctionalTest {
     @Parameterized.Parameters(name = "Gradle {0}")
     static List<Object[]> data() {
         return [
-                ["7.0-rc-1", ["generateGitProperties", "--configuration-cache", "--build-cache"]],
-                ["6.8.3", ["generateGitProperties", "--configuration-cache", "--build-cache"]],
-                ["6.7.1", ["generateGitProperties", "--configuration-cache", "--build-cache"]],
-                ["6.6.1", ["generateGitProperties", "--configuration-cache", "--build-cache"]],
-                ["6.5.1", ["generateGitProperties"]],
-                ["6.4.1", ["generateGitProperties"]],
-                // ["6.3", ["generateGitProperties"]], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
-                // ["6.2.2", ["generateGitProperties"]], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
-                // ["6.1.1", ["generateGitProperties"]], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
-                // ["6.0.1", ["generateGitProperties"]], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
-                ["5.6.4", ["generateGitProperties"]],
-                ["5.5.1", ["generateGitProperties"]],
-                ["5.1", ["generateGitProperties"]],
-                // ["5.0", ["generateGitProperties"]], // Doesn't support conventions: https://docs.gradle.org/5.1/release-notes.html#specify-a-convention-for-a-property
-                // ["4.10.3", ["generateGitProperties"]]
+                ["7.0-rc-1", ["generateGitProperties", "--configuration-cache", "--build-cache"], "16"],
+                ["6.8.3", ["generateGitProperties", "--configuration-cache", "--build-cache"], "15"],
+                ["6.7.1", ["generateGitProperties", "--configuration-cache", "--build-cache"], "15"],
+                ["6.6.1", ["generateGitProperties", "--configuration-cache", "--build-cache"], "15"],
+                ["6.5.1", ["generateGitProperties"], "15"],
+                ["6.4.1", ["generateGitProperties"], "15"],
+                // ["6.3", ["generateGitProperties"], "15"], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
+                // ["6.2.2", ["generateGitProperties"], "15"], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
+                // ["6.1.1", ["generateGitProperties"], "15"], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
+                // ["6.0.1", ["generateGitProperties"], "15"], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
+                ["5.6.4", ["generateGitProperties"], "12"],
+                ["5.5.1", ["generateGitProperties"], "12"],
+                ["5.1", ["generateGitProperties"], "12"],
+                // ["5.0", ["generateGitProperties"], "12"], // Doesn't support conventions: https://docs.gradle.org/5.1/release-notes.html#specify-a-convention-for-a-property
         ]*.toArray()
     }
 
     private final String gradleVersion;
     private final List<String> arguments;
+    private final String maxJavaVersion;
 
-    BackwardCompatibilityFunctionalTest(String gradleVersion, List<String> arguments) {
+    BackwardCompatibilityFunctionalTest(String gradleVersion, List<String> arguments, String maxJavaVersion) {
         this.gradleVersion = gradleVersion
         this.arguments = arguments
+        this.maxJavaVersion = maxJavaVersion
     }
 
     @Test
     public void testPluginSupportsConfigurationCache() {
+        def javaVersion = System.getProperty("java.version", "99");
+        Assume.assumeTrue("Skipping test on Java ${javaVersion}", javaVersion <= maxJavaVersion);
+
         def projectDir = temporaryFolder.newFolder()
 
         GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->

--- a/src/test/groovy/com/gorylenko/BackwardCompatibilityFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/BackwardCompatibilityFunctionalTest.groovy
@@ -1,0 +1,77 @@
+package com.gorylenko
+
+import com.gorylenko.properties.GitRepositoryBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import static org.junit.Assert.assertEquals
+
+@RunWith(Parameterized.class)
+public class BackwardCompatibilityFunctionalTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Parameterized.Parameters(name = "Gradle {0}")
+    static List<Object[]> data() {
+        return [
+                ["7.0-rc-1", ["generateGitProperties", "--configuration-cache", "--build-cache"]],
+                ["6.8.3", ["generateGitProperties", "--configuration-cache", "--build-cache"]],
+                ["6.7.1", ["generateGitProperties", "--configuration-cache", "--build-cache"]],
+                ["6.6.1", ["generateGitProperties", "--configuration-cache", "--build-cache"]],
+                ["6.5.1", ["generateGitProperties"]],
+                ["6.4.1", ["generateGitProperties"]],
+                // ["6.3", ["generateGitProperties"]], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
+                // ["6.2.2", ["generateGitProperties"]], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
+                // ["6.1.1", ["generateGitProperties"]], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
+                // ["6.0.1", ["generateGitProperties"]], // StackOverflowError: https://github.com/gradle/gradle/issues/11466
+                ["5.6.4", ["generateGitProperties"]],
+                ["5.5.1", ["generateGitProperties"]],
+                ["5.1", ["generateGitProperties"]],
+                // ["5.0", ["generateGitProperties"]], // Doesn't support conventions: https://docs.gradle.org/5.1/release-notes.html#specify-a-convention-for-a-property
+                // ["4.10.3", ["generateGitProperties"]]
+        ]*.toArray()
+    }
+
+    private final String gradleVersion;
+    private final List<String> arguments;
+
+    BackwardCompatibilityFunctionalTest(String gradleVersion, List<String> arguments) {
+        this.gradleVersion = gradleVersion
+        this.arguments = arguments
+    }
+
+    @Test
+    public void testPluginSupportsConfigurationCache() {
+        def projectDir = temporaryFolder.newFolder()
+
+        GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->
+            // commit 1 new file "hello.txt"
+            gitRepoBuilder.commitFile("hello.txt", "Hello", "Added hello.txt")
+        })
+
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('java')
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withGradleVersion(gradleVersion)
+                .withPluginClasspath()
+                .withArguments(arguments)
+                .withProjectDir(projectDir)
+
+        def result = runner.build()
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+
+        result = runner.build()
+        assertEquals(TaskOutcome.UP_TO_DATE, result.task(":generateGitProperties").outcome)
+    }
+}

--- a/src/test/groovy/com/gorylenko/BasicFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/BasicFunctionalTest.groovy
@@ -1,0 +1,86 @@
+package com.gorylenko
+
+import com.gorylenko.properties.GitRepositoryBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+public class BasicFunctionalTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    public void testPluginFailsWithoutGitDirectory() {
+        def projectDir = temporaryFolder.newFolder()
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withArguments("generateGitProperties")
+                .withProjectDir(projectDir)
+
+        def result = runner.buildAndFail()
+
+        assertEquals(TaskOutcome.FAILED, result.task(":generateGitProperties").outcome)
+        assertTrue(result.output.contains("No Git repository found."))
+    }
+
+    @Test
+    public void testPluginSucceedsWithoutGitDirectoryAndFailOnNoGitDirectoryFalse() {
+        def projectDir = temporaryFolder.newFolder()
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('com.gorylenko.gradle-git-properties')
+            }
+            gitProperties {
+                failOnNoGitDirectory = false
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withArguments("generateGitProperties")
+                .withProjectDir(projectDir)
+
+        def result = runner.build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+    }
+
+    @Test
+    public void testPluginSucceedsWithGitDirectory() {
+        def projectDir = temporaryFolder.newFolder()
+
+        GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->
+            // commit 1 new file "hello.txt"
+            gitRepoBuilder.commitFile("hello.txt", "Hello", "Added hello.txt")
+        })
+
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withArguments("generateGitProperties")
+                .withProjectDir(projectDir)
+
+        def result = runner.build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+    }
+}

--- a/src/test/groovy/com/gorylenko/BuildCacheFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/BuildCacheFunctionalTest.groovy
@@ -1,0 +1,49 @@
+package com.gorylenko
+
+import com.gorylenko.properties.GitRepositoryBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static org.junit.Assert.assertEquals
+
+public class BuildCacheFunctionalTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    public void testPluginSupportsBuildCache() {
+        def projectDir = temporaryFolder.newFolder()
+
+        GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->
+            // commit 1 new file "hello.txt"
+            gitRepoBuilder.commitFile("hello.txt", "Hello", "Added hello.txt")
+        })
+
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('java')
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withArguments("generateGitProperties", "--build-cache")
+                .withProjectDir(projectDir)
+
+        def firstResult = runner.build()
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":generateGitProperties").outcome)
+
+        def secondResult = runner.build()
+        assertEquals(TaskOutcome.UP_TO_DATE, secondResult.task(":generateGitProperties").outcome)
+
+        runner.withArguments("clean").build()
+
+        def thirdResult = runner.withArguments("generateGitProperties", "--build-cache").build()
+        assertEquals(TaskOutcome.FROM_CACHE, thirdResult.task(":generateGitProperties").outcome)
+    }
+}

--- a/src/test/groovy/com/gorylenko/ConfigurationCacheFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/ConfigurationCacheFunctionalTest.groovy
@@ -1,0 +1,46 @@
+package com.gorylenko
+
+import com.gorylenko.properties.GitRepositoryBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+public class ConfigurationCacheFunctionalTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    public void testPluginSupportsConfigurationCache() {
+        def projectDir = temporaryFolder.newFolder()
+
+        GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->
+            // commit 1 new file "hello.txt"
+            gitRepoBuilder.commitFile("hello.txt", "Hello", "Added hello.txt")
+        })
+
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('java')
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withArguments("--configuration-cache", "generateGitProperties")
+                .withProjectDir(projectDir)
+
+        def firstResult = runner.build()
+        assertEquals(TaskOutcome.SUCCESS, firstResult.task(":generateGitProperties").outcome)
+
+        def secondResult = runner.build()
+        assertTrue(secondResult.output.contains('Reusing configuration cache.'))
+        assertEquals(TaskOutcome.UP_TO_DATE, secondResult.task(":generateGitProperties").outcome)
+    }
+}

--- a/src/test/groovy/com/gorylenko/GitPropertiesPluginTests.groovy
+++ b/src/test/groovy/com/gorylenko/GitPropertiesPluginTests.groovy
@@ -38,7 +38,7 @@ class GitPropertiesPluginTests {
 
         // FIXME: Didn't find any way to change `rootProject`, so just set the property.
         GitPropertiesPluginExtension ext = project.getExtensions().getByName("gitProperties")
-        ext.dotGitDirectory = new File(projectDir, '.git')
+        ext.dotGitDirectory.set(new File(projectDir, '.git'))
 
         def task = project.tasks.generateGitProperties
         assertTrue(task instanceof GenerateGitPropertiesTask)
@@ -62,7 +62,7 @@ class GitPropertiesPluginTests {
 
         // FIXME: Didn't find any way to change `rootProject`, so just set the property.
         GitPropertiesPluginExtension ext = project.getExtensions().getByName("gitProperties")
-        ext.dotGitDirectory = projectDir
+        ext.dotGitDirectory.set(projectDir)
         ext.failOnNoGitDirectory = false;
 
         def task = project.tasks.generateGitProperties
@@ -82,10 +82,10 @@ class GitPropertiesPluginTests {
 
         // FIXME: Didn't find any way to change `rootProject`, so just set the property.
         GitPropertiesPluginExtension ext = project.getExtensions().getByName("gitProperties")
-        ext.dotGitDirectory = projectDir
+        ext.dotGitDirectory.set(projectDir)
         // failOnNoGitDirectory is true by default
 
-        def task = project.tasks.generateGitProperties
+        def task = project.tasks.getByName("generateGitProperties")
         assertTrue(task instanceof GenerateGitPropertiesTask)
 
         try {


### PR DESCRIPTION
Remove problematic invocations in the task action and replace them with the recommended replacements from the Gradle documentation.

https://docs.gradle.org/6.8.3/userguide/configuration_cache.html
https://docs.gradle.org/6.8.3/userguide/lazy_configuration.html

Closes #160