### PR TITLE
Remove dependency on JCenter due to its shutdown

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,11 @@ buildScan {
 apply plugin: "com.gradle.plugin-publish"
 
 repositories {
-    jcenter()
+    mavenCentral()
+    maven {
+        name = 'ajoberstar-backup'
+        url = 'https://ajoberstar.github.io/bintray-backup/'
+    }
     // for debugging
     //maven {
     //    url 'https://repo.gradle.org/gradle/libs-releases-local/'


### PR DESCRIPTION
Replace JCenter with Maven Central and the static repository of @ajoberstar.

Closes #166