### PR TITLE
Make plugin work during configuration phase again

### DIFF
--- a/src/main/groovy/com/gorylenko/GenerateGitPropertiesTask.groovy
+++ b/src/main/groovy/com/gorylenko/GenerateGitPropertiesTask.groovy
@@ -148,25 +148,11 @@ public class GenerateGitPropertiesTask extends DefaultTask {
         } else {
             logger.info("Skip writing properties to [${file}] as it is up-to-date.")
         }
-
     }
 
     private File getDotGitDirectory() {
         DirectoryProperty dotGitDirectory = gitProperties.dotGitDirectory
         return new GitDirLocator(layout.projectDirectory.asFile).lookupGitDirectory(dotGitDirectory.asFile.get())
-    }
-
-
-    public void onJavaPluginAvailable() {
-        // if Java plugin is used, this method will be called to register gitPropertiesResourceDir to classpath
-        // at the end of evaluation phase (to make sure extension values are set)
-        logger.debug "GenerateGitPropertiesTask: found Java plugin"
-        if (gitProperties.gitPropertiesResourceDir) {
-            logger.debug("gitProperties.gitPropertiesResourceDir=${gitProperties.gitPropertiesResourceDir}")
-            String gitPropertiesDir = getGitPropertiesDir().asFile.absolutePath
-            project.sourceSets.main.resources.srcDir gitPropertiesDir
-            logger.info "GenerateGitPropertiesTask: added classpath entry(gitPropertiesResourceDir): ${gitPropertiesDir}"
-        }
     }
 
     private Directory getGitPropertiesDir() {

--- a/src/test/groovy/com/gorylenko/BackwardCompatibilityFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/BackwardCompatibilityFunctionalTest.groovy
@@ -20,7 +20,7 @@ public class BackwardCompatibilityFunctionalTest {
     @Parameterized.Parameters(name = "Gradle {0}")
     static List<Object[]> data() {
         return [
-                ["7.0-rc-1", ["generateGitProperties", "--configuration-cache", "--build-cache"], "16"],
+                ["7.0-rc-2", ["generateGitProperties", "--configuration-cache", "--build-cache"], "16"],
                 ["6.8.3", ["generateGitProperties", "--configuration-cache", "--build-cache"], "15"],
                 ["6.7.1", ["generateGitProperties", "--configuration-cache", "--build-cache"], "15"],
                 ["6.6.1", ["generateGitProperties", "--configuration-cache", "--build-cache"], "15"],

--- a/src/test/groovy/com/gorylenko/BuildSrcFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/BuildSrcFunctionalTest.groovy
@@ -1,0 +1,135 @@
+package com.gorylenko
+
+import com.gorylenko.properties.GitRepositoryBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+public class BuildSrcFunctionalTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    public void testPluginSucceedsDuringConfigurationPhase() {
+        def projectDir = temporaryFolder.newFolder()
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withArguments("check")
+                .withProjectDir(projectDir)
+
+        def classpathString = runner.pluginClasspath
+                .collect { "'$it'" }
+                .join(", ")
+
+        def buildSrcDir = new File(projectDir, "buildSrc")
+        buildSrcDir.mkdirs()
+        new File(buildSrcDir, "build.gradle") << """\
+            plugins {
+                id("groovy-gradle-plugin")
+            }
+            repositories {
+                gradlePluginPortal()
+            }
+            dependencies {
+                runtimeClasspath files($classpathString)
+            }
+        """
+        def pluginSourceDir = buildSrcDir.toPath().resolve("src").resolve("main").resolve("groovy").toFile()
+        pluginSourceDir.mkdirs()
+        new File(pluginSourceDir, "test-plugin.gradle") << """\
+            plugins {
+                id("java")
+                id("com.gorylenko.gradle-git-properties")
+            }
+        """
+        new File(projectDir, "settings.gradle") << """\
+            pluginManagement {
+                plugins {
+                    id("com.gorylenko.gradle-git-properties")
+                }
+            }
+        """.stripIndent()
+        new File(projectDir, "build.gradle") << """\
+            plugins {
+                id("test-plugin")
+            }
+        """.stripIndent()
+
+        GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->
+            // commit 1 new file "hello.txt"
+            gitRepoBuilder.commitFile("hello.txt", "Hello", "Added hello.txt")
+        })
+
+        def result = runner.build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+    }
+
+    @Test
+    public void testPluginCanOverrideGitPropertiesResourceDir() {
+        def projectDir = temporaryFolder.newFolder()
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withArguments("check")
+                .withProjectDir(projectDir)
+
+        def classpathString = runner.pluginClasspath
+                .collect { "'$it'" }
+                .join(", ")
+
+        def buildSrcDir = new File(projectDir, "buildSrc")
+        buildSrcDir.mkdirs()
+        def gitPropDir = new File(projectDir, "gitProp")
+        gitPropDir.mkdirs()
+        new File(buildSrcDir, "build.gradle") << """\
+            plugins {
+                id("groovy-gradle-plugin")
+            }
+            repositories {
+                gradlePluginPortal()
+            }
+            dependencies {
+                runtimeClasspath files($classpathString)
+            }
+        """
+        def pluginSourceDir = buildSrcDir.toPath().resolve("src").resolve("main").resolve("groovy").toFile()
+        pluginSourceDir.mkdirs()
+        new File(pluginSourceDir, "test-plugin.gradle") << """\
+            plugins {
+                id("java")
+                id("com.gorylenko.gradle-git-properties")
+            }
+        """
+        new File(projectDir, "settings.gradle") << """\
+            pluginManagement {
+                plugins {
+                    id("com.gorylenko.gradle-git-properties")
+                }
+            }
+        """.stripIndent()
+        new File(projectDir, "build.gradle") << """\
+            plugins {
+                id("test-plugin")
+            }
+            
+            gitProperties {
+                gitPropertiesResourceDir = layout.projectDirectory.dir("gitProp")
+            }
+        """.stripIndent()
+
+        GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->
+            // commit 1 new file "hello.txt"
+            gitRepoBuilder.commitFile("hello.txt", "Hello", "Added hello.txt")
+        })
+
+        def result = runner.build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+        assertTrue(gitPropDir.list().contains("git.properties"))
+    }
+}


### PR DESCRIPTION
The changes in #164 to support the Gradle configuration cache broke using the plugin during the configuration phase of Gradle (e. g. as part of a custom plugin via `buildSrc` and similar use cases).

Instead of relying on [`Gradle#projectsEvaluated()`](https://docs.gradle.org/6.8.3/javadoc/org/gradle/api/invocation/Gradle.html#projectsEvaluated-groovy.lang.Closure-) which isn't available during the configuration phase to add additional resource directories to the `main` source set, the plugin now lazily modifies the main source set.

Fixes #169