### PR TITLE
Add Java 16 to Travis CI and upgrade to Gradle 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,7 @@ jdk:
   - openjdk13
   - openjdk14
   - openjdk15
-# Gradle currently doesn't support Java 16 or higher.
-# See also: https://github.com/gradle/gradle/issues/13629
-# See also: https://github.com/gradle/gradle/issues/13481
-#
-#  - openjdk16
-#  - openjdk-ea
+  - openjdk16
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
     mavenCentral()
     maven {
         name = 'ajoberstar-backup'
-        url = 'https://ajoberstar.github.io/bintray-backup/'
+        url = 'https://ajoberstar.org/bintray-backup/'
     }
     // for debugging
     //maven {

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'groovy'
     id 'maven-publish'
     id 'java-gradle-plugin'
-    id "com.gradle.plugin-publish" version "0.13.0"
-    id "com.gorylenko.gradle-git-properties" version "2.2.4"
+    id "com.gradle.plugin-publish" version "0.14.0"
+    id "com.gorylenko.gradle-git-properties" version "2.3.1-rc3"
 }
 
 buildScan {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 plugins {
-    id "com.gradle.enterprise" version "3.5.2"
+    id "com.gradle.enterprise" version "3.6.1"
 }


### PR DESCRIPTION
After OpenJDK 16 was disabled in #165 because the plugin was incompatible at that time, it should now work with Gradle 7.0 and Java 16.

Refs #173