### PR TITLE
doc(dotGitDirectory): add kotlin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ gitProperties {
 }
 ```
 
+Note: Kotlin DSL syntax
+```kotlin
+configure<com.gorylenko.GitPropertiesPluginExtension> {
+    (dotGitDirectory as DirectoryProperty).set("${project.rootDir}/../somefolder/.git")
+}
+```
+
 If for some reason, the `.git` directory for the project doesn't exist and you don't want the task to fail in that case, use `failOnNoGitDirectory=false`:
 
 ```groovy


### PR DESCRIPTION
Add a Kotlin example for the `dotGitDirectory`. Currently, the code doesn't contains type information, so we have to cast it at config level. 

Maybe a modification at code level would be better, but I don't have the time to investigate on it for now. 