### PR TITLE
Update grgit-core to 4.1.1 (Fix #195)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This Gradle plugin is compatible with the following versions of Gradle:
 * Plugin requires Java 8+
 * If `git.properties` is missing on Gradle 5.1.x and 5.2.x [Issue 128](https://github.com/n0mer/gradle-git-properties/issues/128), use `gitPropertiesResourceDir` to config a different output directory 
 * Since gradle-git-properties v2.x, we require JGit 5.x, this might cause some issues if you have other gradle plugin which uses JGit 1.4.x. In that case, you can use gradle-git-properties v1.5.x (instead of 2.x) which uses JGit 1.4.x. See [Issue 133](https://github.com/n0mer/gradle-git-properties/issues/133) for more info about this plugin's dependencies
+* With gradle-git-properties v2.2.4, v2.3.0, and v2.3.1, grgit v4.1.0 always requires the latest JGit which can be 6+, this cause build fails if you run Gradle with Java under 11. See [Issue 195](https://github.com/n0mer/gradle-git-properties/issues/195) for more info about this issue
 
 ## usage
 

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 dependencies {
     shadow gradleApi()
     shadow localGroovy()
-    implementation 'org.ajoberstar.grgit:grgit-core:4.1.0'
+    implementation 'org.ajoberstar.grgit:grgit-core:4.1.1'
     // for debugging
     //implementation 'org.gradle:gradle-language-jvm:5.6.2'
     //implementation 'org.gradle:gradle-language-java:5.6.2'


### PR DESCRIPTION
Fix #195

We've used grgit v4.1.0 since 76a0f0aaa20317cd7e694f244080e1c7b4a74c5a, which included in v2.2.4 to v2.3.1.

Reference for grgit v4.1.1: ajoberstar/grgit#339