### PR TITLE
Exclude slf4j-api from grgit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,14 @@ repositories {
     //}
 }
 
+def integrationTest = sourceSets.create("integrationTest")
+
 dependencies {
     shadow gradleApi()
     shadow localGroovy()
-    implementation 'org.ajoberstar.grgit:grgit-core:4.1.1'
+    implementation('org.ajoberstar.grgit:grgit-core:4.1.1') {
+        exclude(group: 'org.slf4j')
+    }
     // for debugging
     //implementation 'org.gradle:gradle-language-jvm:5.6.2'
     //implementation 'org.gradle:gradle-language-java:5.6.2'
@@ -47,6 +51,11 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation gradleTestKit()
+
+    integrationTestImplementation 'junit:junit:4.12'
+    integrationTestImplementation gradleTestKit()
+    integrationTestImplementation project
+    integrationTestImplementation sourceSets.test.output // Include test files for git project utils
 }
 
 task relocateShadowJar(type: ConfigureShadowRelocation) {
@@ -83,6 +92,16 @@ test {
         events "passed", "skipped", "failed"
         exceptionFormat "full"
     }
+}
+
+tasks.register("integrationTest", Test) {
+    dependsOn tasks.shadowJar
+
+    description = 'Runs the integration tests.'
+    group = "verification"
+    testClassesDirs = integrationTest.output.classesDirs
+    classpath = integrationTest.runtimeClasspath
+    it.systemProperty "integration.plugin.path", tasks.shadowJar.outputs.getFiles().asPath // Pass java system property indicating integration plugin path
 }
 
 tasks.register("sourceJar", Jar) {

--- a/src/integrationTest/groovy/com/gorylenko/SLF4JBindingPostShadowTest.groovy
+++ b/src/integrationTest/groovy/com/gorylenko/SLF4JBindingPostShadowTest.groovy
@@ -1,0 +1,45 @@
+package com.gorylenko
+
+import com.gorylenko.properties.GitRepositoryBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class SLF4JBindingPostShadowTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    void testSFL4JBindingPostShadow() {
+        def projectDir = temporaryFolder.newFolder()
+
+        def integrationPluginPath = System.properties.get("integration.plugin.path") // Fetch integration jar from shadowJar output
+        Assert.assertNotNull("integration.plugin.path was null", integrationPluginPath)
+
+        GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->
+            // commit 1 new file "hello.txt"
+            gitRepoBuilder.commitFile("hello.txt", "Hello", "Added hello.txt")
+        })
+
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withPluginClasspath(Arrays.asList(new File(integrationPluginPath as String))) // Use integration plugin jar
+                .withArguments("generateGitProperties")
+                .withProjectDir(projectDir)
+
+        def result = runner.build()
+
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+        Assert.assertFalse("Project improperly shadowed slf4j-api!", result.output.contains("org.slf4j.impl.StaticLoggerBinder"))
+    }
+
+}


### PR DESCRIPTION
To prevent the plugin from shipping its own slf4j-api jar,
which is improperly relocated and hence fails to bind to the gradle
provided sfl4j implementation, this commit excludes the slf4j-api from
grgit.

The commit additionally contains an integration test that tests the
shadowed plugin jar to ensure slf4j can properly bind.

Resolves: #203