### PR TITLE
Gradle 8.7 works with configuration cache

### DIFF
--- a/src/test/groovy/com/gorylenko/BackwardCompatibilityFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/BackwardCompatibilityFunctionalTest.groovy
@@ -20,6 +20,7 @@ public class BackwardCompatibilityFunctionalTest {
     @Parameterized.Parameters(name = "Gradle {0}")
     static List<Object[]> data() {
         return [
+                ["8.7", ["generateGitProperties", "--configuration-cache", "--build-cache"], "17"],
                 ["7.0", ["generateGitProperties", "--configuration-cache", "--build-cache"], "17"],
                 ["6.8.3", ["generateGitProperties", "--configuration-cache", "--build-cache"], "15"],
                 ["6.7.1", ["generateGitProperties", "--configuration-cache", "--build-cache"], "15"],

--- a/src/test/groovy/com/gorylenko/properties/BranchPropertyTest.groovy
+++ b/src/test/groovy/com/gorylenko/properties/BranchPropertyTest.groovy
@@ -24,6 +24,7 @@ class BranchPropertyTest {
         projectDir = File.createTempDir("BranchPropertyTest", ".tmp")
 
         GitRepositoryBuilder.setupProjectDir(projectDir, { gitRepoBuilder ->
+            gitRepoBuilder
             // empty repo
         })
 


### PR DESCRIPTION
First try to make in compatible with configuration cache in gradle 8.7. Further refactoring needed. 
Changes: Detection of .git-dir not possible during configration phase -> Logic of GitDirLocator without usage of jgit?