### PR TITLE
Bump version to 2.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Declare this in your `build.gradle`
 
 ```groovy
 plugins {
-  id "com.gorylenko.gradle-git-properties" version "2.5.2"
+  id "com.gorylenko.gradle-git-properties" version "2.5.3"
 }
 ```
 
@@ -294,7 +294,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath ("com.gorylenko.gradle-git-properties:gradle-git-properties:2.5.2") {
+    classpath ("com.gorylenko.gradle-git-properties:gradle-git-properties:2.5.3") {
         exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit' // remove plugin's jgit dependency
     }
     classpath 'org.eclipse.jgit:org.eclipse.jgit:5.5.0.201909110433-r' // use the specified jgit dependency

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ components.java.withVariantsFromConfiguration(configurations.runtimeElements) {
     skip()
 }
 
-version = "2.5.2"
+version = "2.5.3"
 group = "com.gorylenko.gradle-git-properties"
 
 gitProperties {


### PR DESCRIPTION
- Update project version in build.gradle from 2.5.2 to 2.5.3
- Update plugin version references in README.md documentation
- Update both usage example and buildscript example to reflect new version