### PR TITLE
Set root project name in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
 plugins {
     id "com.gradle.enterprise" version "3.6.1"
 }
+
+rootProject.name = "gradle-git-properties"


### PR DESCRIPTION
It appears the working directory name used when uploading the plugin is being used directly as the artifactId. Since fixing the artifactId in settings.gradle is the standard approach, I implemented that solution.

Added 'rootProject.name = "gradle-git-properties"' to settings.gradle to explicitly define the project's root name.

fix #255