### PR TITLE
chore: bump version to 2.5.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Add the plugin to your build file:
 **Groovy DSL** (`build.gradle`)
 ```groovy
 plugins {
-    id "com.gorylenko.gradle-git-properties" version "2.5.6"
+    id "com.gorylenko.gradle-git-properties" version "2.5.7"
 }
 ```
 
 **Kotlin DSL** (`build.gradle.kts`)
 ```kotlin
 plugins {
-    id("com.gorylenko.gradle-git-properties") version "2.5.6"
+    id("com.gorylenko.gradle-git-properties") version "2.5.7"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ components.java.withVariantsFromConfiguration(configurations.runtimeElements) {
     skip()
 }
 
-version = "2.5.6"
+version = "2.5.7"
 group = "com.gorylenko.gradle-git-properties"
 
 gitProperties {


### PR DESCRIPTION
## Summary
- Bump plugin version from 2.5.6 to 2.5.7
- Update version references in README.md installation examples

This release follows the README documentation improvements merged in PR #285.

## Changes
- `build.gradle`: version 2.5.6 → 2.5.7
- `README.md`: Update Groovy and Kotlin DSL examples to 2.5.7