### PR TITLE
fix: support symlinked .git directories (Gerrit repo compatibility)

### DIFF
--- a/src/main/groovy/com/gorylenko/GitProperties.groovy
+++ b/src/main/groovy/com/gorylenko/GitProperties.groovy
@@ -27,6 +27,7 @@ import com.gorylenko.properties.TagsProperty
 import com.gorylenko.properties.TotalCommitCountProperty
 
 import java.io.File
+import java.nio.file.Files
 import java.util.List
 import java.util.Map
 
@@ -66,7 +67,13 @@ class GitProperties {
         // Evaluate property values
 
         def result = [:]
-        def repo = Grgit.open(dir: dotGitDirectory)
+        def repo
+        if (dotGitDirectory.name == ".git" && Files.isSymbolicLink(dotGitDirectory.toPath())) {
+            // For symlinked .git directories (e.g., Gerrit repo), open from working tree
+            repo = Grgit.open(currentDir: dotGitDirectory.parentFile)
+        } else {
+            repo = Grgit.open(dir: dotGitDirectory)
+        }
         try {
             properties.each{ k, v -> result.put(k, v instanceof Closure ? v.call(repo).toString() : v.toString() ) }
         } finally {

--- a/src/test/groovy/com/gorylenko/SymlinkGitDirectoryFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/SymlinkGitDirectoryFunctionalTest.groovy
@@ -1,0 +1,131 @@
+package com.gorylenko
+
+import com.gorylenko.properties.GitRepositoryBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assume
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import java.nio.file.Files
+
+import static org.hamcrest.CoreMatchers.containsString
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
+
+class SymlinkGitDirectoryFunctionalTest {
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    void testPluginWorksWithSymlinkedGitDirectory() {
+        // Skip on Windows where symlinks may require elevated privileges
+        Assume.assumeTrue("Skipping symlink test on Windows", !System.getProperty("os.name").toLowerCase().contains("windows"))
+
+        // Setup main repository
+        def mainRepoDir = temporaryFolder.newFolder("main-repo")
+        GitRepositoryBuilder.setupProjectDir(mainRepoDir, { builder ->
+            builder.commitFile("test.txt", "test content", "Initial commit")
+        })
+
+        // Create a project directory with .git as a symlink (simulating Gerrit repo structure)
+        def projectDir = temporaryFolder.newFolder("project-with-symlink")
+        def mainGitDir = new File(mainRepoDir, ".git")
+        def symlinkGitDir = new File(projectDir, ".git")
+
+        // Create symlink: project/.git -> main-repo/.git
+        Files.createSymbolicLink(symlinkGitDir.toPath(), mainGitDir.toPath())
+
+        // Verify symlink was created
+        assertTrue("Symlink should exist", symlinkGitDir.exists())
+        assertTrue("Should be a symlink", Files.isSymbolicLink(symlinkGitDir.toPath()))
+
+        // Setup build files
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDir)
+                .withArguments('generateGitProperties', '--info')
+                .forwardOutput()
+                .build()
+
+        assertEquals(TaskOutcome.SUCCESS, runner.task(":generateGitProperties").outcome)
+        // Verify dotGitDirectory was detected (path may vary due to macOS /var -> /private/var symlink)
+        assertThat(runner.output, containsString("dotGitDirectory = ["))
+
+        def gitPropertiesFile = new File(projectDir, "build/resources/main/git.properties")
+        assertTrue("git.properties file should exist", gitPropertiesFile.exists())
+
+        // Verify properties were generated correctly
+        def properties = new Properties()
+        gitPropertiesFile.withInputStream { properties.load(it) }
+        assertTrue("Should have git.commit.id", properties.containsKey("git.commit.id"))
+        assertTrue("Should have git.branch", properties.containsKey("git.branch"))
+    }
+
+    @Test
+    void testPluginWorksWithRelativeSymlinkedGitDirectory() {
+        // Skip on Windows where symlinks may require elevated privileges
+        Assume.assumeTrue("Skipping symlink test on Windows", !System.getProperty("os.name").toLowerCase().contains("windows"))
+
+        // Setup: Create structure like Gerrit repo
+        // base/
+        //   actual-repo/       (full git repo with working tree)
+        //     .git/
+        //   myproject/
+        //     .git -> ../actual-repo/.git
+
+        def baseDir = temporaryFolder.newFolder("base")
+
+        // Create the actual git repository with working tree
+        def actualRepoDir = new File(baseDir, "actual-repo")
+        actualRepoDir.mkdirs()
+        GitRepositoryBuilder.setupProjectDir(actualRepoDir, { builder ->
+            builder.commitFile("test.txt", "test content", "Initial commit")
+        })
+
+        def actualGitDir = new File(actualRepoDir, ".git")
+
+        // Create project directory
+        def projectDir = new File(baseDir, "myproject")
+        projectDir.mkdirs()
+
+        // Create relative symlink: myproject/.git -> ../actual-repo/.git
+        def symlinkGitDir = new File(projectDir, ".git")
+        def relativePath = projectDir.toPath().relativize(actualGitDir.toPath())
+        Files.createSymbolicLink(symlinkGitDir.toPath(), relativePath)
+
+        // Setup build files
+        new File(projectDir, "settings.gradle") << ""
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+
+        def runner = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDir)
+                .withArguments('generateGitProperties', '--info')
+                .forwardOutput()
+                .build()
+
+        assertEquals(TaskOutcome.SUCCESS, runner.task(":generateGitProperties").outcome)
+
+        def gitPropertiesFile = new File(projectDir, "build/resources/main/git.properties")
+        assertTrue("git.properties file should exist", gitPropertiesFile.exists())
+
+        // Verify properties were generated correctly
+        def properties = new Properties()
+        gitPropertiesFile.withInputStream { properties.load(it) }
+        assertTrue("Should have git.commit.id", properties.containsKey("git.commit.id"))
+    }
+}


### PR DESCRIPTION
### Issue: Plugin fails with symlinked .git directories (Gerrit repo)

#### Problem

When using this plugin in a project where `.git` is a symlink (in my case Gerrit repo tool setups), the build fails with:

Execution failed for task ':generateGitProperties'.
> Bare Repository has neither a working tree, nor an index

##### Expected when:

- Gerrit repo tool users
- Anyone with custom symlinked repository structures
- Monorepo setups that symlink .git to a central location

#### Environment

- Gerrit repo tool creates a structure where each project's `.git` is a symlink pointing to `.repo/projects/<project>.git`
- Example: `myproject/.git` → `../../.repo/projects/myproject.git`

#### Root Cause

`Grgit.open(dir: dotGitDirectory)` fails when `dotGitDirectory` is a symlink because JGit cannot resolve the working tree relationship through the symlink. It sees the git database but has no way to find the associated working tree.

#### Solution

Detect when `.git` is a symlink and use `Grgit.open(currentDir: dotGitDirectory.parentFile)` instead. This opens from the working tree directory, allowing JGit to find and follow the .git symlink internally.

#### Testing

- Added functional tests for absolute and relative symlinked `.git` directories
- Verified against a real Gerrit repo project structure