### PR TITLE
docs: update Docker image in DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,7 @@
 ## Docker Build and Publish
 
 ```bash
-docker run --rm -v $(pwd):/gradle-git-properties -w /gradle-git-properties openjdk:17 ./gradlew publishPlugins -Pgradle.publish.key=your_key -Pgradle.publish.secret=your_secret
+docker run --rm -v $(pwd):/gradle-git-properties -v ~/.gradle:/root/.gradle -w /gradle-git-properties eclipse-temurin:17 ./gradlew clean publishPlugins -Pgradle.publish.key=your_key -Pgradle.publish.secret=your_secret
 ```
 
 **Note:** The working directory must match the project name (`gradle-git-properties`) to ensure the correct artifactId is published to Maven Central. Using a generic name like `/app` will cause Gradle to publish with the wrong artifactId (see issue #255).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,7 +3,13 @@
 ## Docker Build and Publish
 
 ```bash
-docker run --rm -v $(pwd):/gradle-git-properties -v ~/.gradle:/root/.gradle -w /gradle-git-properties eclipse-temurin:17 ./gradlew clean publishPlugins -Pgradle.publish.key=your_key -Pgradle.publish.secret=your_secret
+docker run --rm -v $(pwd):/gradle-git-properties -v ~/.gradle:/root/.gradle -w /gradle-git-properties eclipse-temurin:17 ./gradlew clean publishPlugins
+```
+
+**Note:** Credentials are read from `~/.gradle/gradle.properties` (mounted into container). Add these to your local file:
+```properties
+gradle.publish.key=your_key
+gradle.publish.secret=your_secret
 ```
 
 **Note:** The working directory must match the project name (`gradle-git-properties`) to ensure the correct artifactId is published to Maven Central. Using a generic name like `/app` will cause Gradle to publish with the wrong artifactId (see issue #255).


### PR DESCRIPTION
## Summary
- Replace deprecated `openjdk:17` with `eclipse-temurin:17`
- Mount `~/.gradle` for credentials access
- Add `clean` task before publishing

Fixes #293