### PR TITLE
fix: worktree builds now detect shared refs changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Add the plugin to your build file:
 **Groovy DSL** (`build.gradle`)
 ```groovy
 plugins {
-    id "com.gorylenko.gradle-git-properties" version "3.0.0"
+    id "com.gorylenko.gradle-git-properties" version "3.0.1"
 }
 ```
 
 **Kotlin DSL** (`build.gradle.kts`)
 ```kotlin
 plugins {
-    id("com.gorylenko.gradle-git-properties") version "3.0.0"
+    id("com.gorylenko.gradle-git-properties") version "3.0.1"
 }
 ```
 

--- a/src/main/groovy/com/gorylenko/GenerateGitPropertiesTask.groovy
+++ b/src/main/groovy/com/gorylenko/GenerateGitPropertiesTask.groovy
@@ -1,5 +1,6 @@
 package com.gorylenko
 
+import com.gorylenko.jgit.RepositoryFactory
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Transformer
@@ -41,12 +42,18 @@ class GenerateGitPropertiesTask extends DefaultTask {
 
         // we will not be able to access the project in the @TaskAction method,
         // if the configuration cache is enabled
-        File gitDir = resolveGitDir(gitProperties.dotGitDirectory.get().asFile)
-        this.source = gitDir?.isDirectory() ? project.fileTree(gitDir) {
-            include('config')
-            include('HEAD')
-            include('refs/**')
-        } : project.files().asFileTree
+        List<File> watchDirs = RepositoryFactory.getDirectoriesToWatch(
+            gitProperties.dotGitDirectory.get().asFile)
+        this.source = watchDirs.isEmpty()
+            ? project.files().asFileTree
+            : watchDirs.collect { dir ->
+                project.fileTree(dir) {
+                    include('config')
+                    include('HEAD')
+                    include('refs/**')
+                    include('packed-refs')
+                }
+            }.inject { acc, tree -> acc.plus(tree) }
         this.projectVersion = project.objects.property(String).convention(project.provider { project.version?.toString() })
 
         outputs.upToDateWhen { GenerateGitPropertiesTask task ->
@@ -172,18 +179,4 @@ class GenerateGitPropertiesTask extends DefaultTask {
         return fileProperty
     }
 
-    // Resolves .git file (worktree) to actual gitdir, or returns directory as-is
-    private static File resolveGitDir(File dotGit) {
-        if (dotGit == null || !dotGit.exists()) return null
-        if (dotGit.isDirectory()) return dotGit
-        if (!dotGit.isFile()) return null
-
-        // Worktree: .git file contains "gitdir: <path>"
-        def content = dotGit.text?.trim()
-        if (!content?.startsWith('gitdir:')) return null
-
-        def gitPath = content.substring(7).trim()
-        def gitDir = new File(gitPath)
-        return gitDir.isAbsolute() ? gitDir : new File(dotGit.parentFile, gitPath).canonicalFile
-    }
 }

--- a/src/main/groovy/com/gorylenko/jgit/RepositoryFactory.groovy
+++ b/src/main/groovy/com/gorylenko/jgit/RepositoryFactory.groovy
@@ -175,6 +175,38 @@ class RepositoryFactory {
         return builder.build()
     }
 
+    /**
+     * Resolves .git file (worktree) to actual gitdir, or returns directory as-is.
+     * Used for determining directories to watch for incremental builds.
+     */
+    private static File resolveDotGit(File dotGit) {
+        if (dotGit == null || !dotGit.exists()) return null
+        if (dotGit.isDirectory()) return dotGit
+        if (!dotGit.isFile()) return null
+        def content = dotGit.text?.trim()
+        if (!content?.startsWith('gitdir:')) return null
+        def gitPath = content.substring(7).trim()
+        def gitDir = new File(gitPath)
+        return gitDir.isAbsolute() ? gitDir : new File(dotGit.parentFile, gitPath).canonicalFile
+    }
+
+    /**
+     * Returns list of directories to watch for git state changes.
+     * For worktrees, returns both worktree gitdir AND main repo gitdir (via commondir).
+     * For regular repos, returns just the git directory.
+     */
+    static List<File> getDirectoriesToWatch(File dotGit) {
+        File gitDir = resolveDotGit(dotGit)
+        if (gitDir == null || !gitDir.isDirectory()) return []
+
+        def commonDirFile = new File(gitDir, "commondir")
+        if (commonDirFile.exists()) {
+            def commonDir = new File(gitDir, commonDirFile.text.trim()).canonicalFile
+            return [gitDir, commonDir]
+        }
+        return [gitDir]
+    }
+
     private static Repository openWorktree(File worktreeDir, File gitFile) {
         def content = gitFile.text.trim()
         if (!content.startsWith("gitdir:")) {

--- a/src/test/groovy/com/gorylenko/SymlinkedGitDirectoryFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/SymlinkedGitDirectoryFunctionalTest.groovy
@@ -1,0 +1,191 @@
+package com.gorylenko
+
+import com.gorylenko.properties.GitRepositoryBuilder
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assume
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import java.nio.file.Files
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+/**
+ * Functional tests for symlinked .git directories.
+ *
+ * Related issues: #287
+ *
+ * Some tools (Gerrit, repo tool) use symlinked .git directories where
+ * the .git directory is a symbolic link to another location:
+ *   - Absolute: .git -> /path/to/real/.git
+ *   - Relative: .git -> ../other-location/.git
+ *
+ * This behavior was originally fixed in PR #287 for Grgit and is now
+ * inherently supported by the JGit migration (#290).
+ */
+class SymlinkedGitDirectoryFunctionalTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    /**
+     * Test that the plugin works when .git is an absolute symlink to another directory.
+     * Example: project/.git -> /some/absolute/path/.git
+     */
+    @Test
+    void testPluginWorksWithAbsoluteSymlinkedGitDirectory() {
+        assumeNotWindows()
+
+        // 1. Create git-storage directory with actual git repo
+        def gitStorageDir = temporaryFolder.newFolder("git-storage")
+        GitRepositoryBuilder.setupProjectDir(gitStorageDir, { builder ->
+            builder.commitFile("README.md", "Test content", "Initial commit for symlink test")
+        })
+
+        // 2. Create working-project directory (no git)
+        def workingProjectDir = temporaryFolder.newFolder("working-project")
+
+        // 3. Create absolute symlink: working-project/.git -> git-storage/.git
+        def storageGitDir = new File(gitStorageDir, ".git")
+        def projectGitSymlink = new File(workingProjectDir, ".git")
+        Files.createSymbolicLink(projectGitSymlink.toPath(), storageGitDir.toPath())
+
+        // 4. Setup gradle build
+        setupGradleBuild(workingProjectDir)
+
+        // 5. Run generateGitProperties task
+        def result = runGradle(workingProjectDir)
+
+        // 6. Verify
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+        assertGitPropertiesValid(workingProjectDir, "Initial commit for symlink test")
+    }
+
+    /**
+     * Test that the plugin works when .git is a relative symlink to another directory.
+     * This mimics how Gerrit/repo tool sets up repositories.
+     * Example: project/.git -> ../git-storage/.git
+     */
+    @Test
+    void testPluginWorksWithRelativeSymlinkedGitDirectory() {
+        assumeNotWindows()
+
+        // 1. Create parent directory to contain both dirs at same level
+        def parentDir = temporaryFolder.newFolder("parent")
+
+        // 2. Create git-storage directory with actual git repo
+        def gitStorageDir = new File(parentDir, "git-storage")
+        gitStorageDir.mkdirs()
+        GitRepositoryBuilder.setupProjectDir(gitStorageDir, { builder ->
+            builder.commitFile("file.txt", "Hello", "Relative symlink test commit")
+        })
+
+        // 3. Create working-project directory
+        def workingProjectDir = new File(parentDir, "working-project")
+        workingProjectDir.mkdirs()
+
+        // 4. Create relative symlink: working-project/.git -> ../git-storage/.git
+        def projectGitSymlink = new File(workingProjectDir, ".git")
+        def relativePath = new File("../git-storage/.git").toPath()
+        Files.createSymbolicLink(projectGitSymlink.toPath(), relativePath)
+
+        // Verify symlink was created correctly
+        assertTrue("Symlink should exist", projectGitSymlink.exists())
+        assertTrue("Symlink target should resolve", new File(workingProjectDir, "../git-storage/.git").exists())
+
+        // 5. Setup gradle build
+        setupGradleBuild(workingProjectDir)
+
+        // 6. Run generateGitProperties task
+        def result = runGradle(workingProjectDir)
+
+        // 7. Verify
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+        assertGitPropertiesValid(workingProjectDir, "Relative symlink test commit")
+    }
+
+    /**
+     * Test that branch information is correctly read through symlinked .git directory.
+     */
+    @Test
+    void testSymlinkedGitDirectoryCorrectlyReadsBranch() {
+        assumeNotWindows()
+
+        // 1. Create git-storage with a specific branch
+        def gitStorageDir = temporaryFolder.newFolder("git-storage-branch")
+        GitRepositoryBuilder.setupProjectDir(gitStorageDir, { builder ->
+            builder.commitFile("main.txt", "main content", "Commit on main")
+            builder.addBranchAndCheckout("feature-branch")
+            builder.commitFile("feature.txt", "feature content", "Commit on feature branch")
+        })
+
+        // 2. Create working-project with symlink
+        def workingProjectDir = temporaryFolder.newFolder("working-project-branch")
+        def storageGitDir = new File(gitStorageDir, ".git")
+        def projectGitSymlink = new File(workingProjectDir, ".git")
+        Files.createSymbolicLink(projectGitSymlink.toPath(), storageGitDir.toPath())
+
+        // 3. Setup and run
+        setupGradleBuild(workingProjectDir)
+        def result = runGradle(workingProjectDir)
+
+        // 4. Verify branch is correctly read
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateGitProperties").outcome)
+
+        def propsFile = new File(workingProjectDir, "build/resources/main/git.properties")
+        assertTrue("git.properties should exist", propsFile.exists())
+
+        def props = new Properties()
+        propsFile.withInputStream { props.load(it) }
+        assertEquals("Should be on feature-branch", "feature-branch", props.getProperty("git.branch"))
+    }
+
+    /**
+     * Skip tests on Windows where symlinks may require elevated privileges.
+     */
+    private void assumeNotWindows() {
+        Assume.assumeFalse("Skipping on Windows - symlinks require elevated privileges",
+                System.getProperty("os.name").toLowerCase().contains("windows"))
+    }
+
+    private void setupGradleBuild(File projectDir) {
+        new File(projectDir, "settings.gradle") << "rootProject.name = 'symlink-test'"
+        new File(projectDir, "build.gradle") << """
+            plugins {
+                id('com.gorylenko.gradle-git-properties')
+            }
+        """.stripIndent()
+    }
+
+    private def runGradle(File projectDir) {
+        return GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectDir)
+                .withArguments('generateGitProperties', '--info')
+                .build()
+    }
+
+    private void assertGitPropertiesValid(File projectDir, String expectedCommitMessage) {
+        def gitPropertiesFile = new File(projectDir, "build/resources/main/git.properties")
+        assertTrue("git.properties file should exist", gitPropertiesFile.exists())
+
+        def properties = new Properties()
+        gitPropertiesFile.withInputStream { properties.load(it) }
+
+        // Verify commit ID is present and valid
+        def commitId = properties.getProperty("git.commit.id")
+        assertTrue("git.commit.id should be present", commitId != null && !commitId.isEmpty())
+        assertTrue("git.commit.id should be a valid SHA", commitId.matches('[a-f0-9]{40}'))
+
+        // Verify commit message
+        def commitMessage = properties.getProperty("git.commit.message.short")
+        assertEquals("Commit message should match", expectedCommitMessage, commitMessage)
+
+        // Verify branch is present
+        def branch = properties.getProperty("git.branch")
+        assertTrue("git.branch should be present", branch != null && !branch.isEmpty())
+    }
+}

--- a/src/test/groovy/com/gorylenko/SymlinkedGitDirectoryFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/SymlinkedGitDirectoryFunctionalTest.groovy
@@ -161,9 +161,25 @@ class SymlinkedGitDirectoryFunctionalTest {
     }
 
     private def runGradle(File projectDir) {
+        // Clear CI environment variables so the test uses git to detect the branch
+        def cleanEnv = System.getenv().findAll { k, v ->
+            !['GITHUB_ACTIONS', 'GITHUB_HEAD_REF', 'GITHUB_REF_NAME',
+              'TRAVIS', 'TRAVIS_BRANCH',
+              'GITLAB_CI', 'CI_COMMIT_REF_NAME',
+              'CIRCLECI', 'CIRCLE_BRANCH',
+              'TF_BUILD', 'BUILD_SOURCEBRANCH',
+              'BITBUCKET_BUILD_NUMBER', 'BITBUCKET_BRANCH',
+              'JOB_NAME', 'GIT_LOCAL_BRANCH', 'GIT_BRANCH', 'BRANCH_NAME',
+              'TEAMCITY_VERSION',
+              'BAMBOO_BUILDKEY', 'BAMBOO_PLANREPOSITORY_BRANCH',
+              'CODEBUILD_BUILD_ARN', 'CODEBUILD_WEBHOOK_HEAD_REF', 'CODEBUILD_WEBHOOK_TRIGGER', 'CODEBUILD_SOURCE_VERSION'
+            ].contains(k)
+        }
+
         return GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(projectDir)
+                .withEnvironment(cleanEnv)
                 .withArguments('generateGitProperties', '--info')
                 .build()
     }

--- a/src/test/groovy/com/gorylenko/WorktreeUpToDateFunctionalTest.groovy
+++ b/src/test/groovy/com/gorylenko/WorktreeUpToDateFunctionalTest.groovy
@@ -1,0 +1,134 @@
+package com.gorylenko
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+import static org.junit.Assert.*
+
+/**
+ * Functional test verifying that worktree builds detect changes
+ * to shared refs (tags, branches) in the main repository.
+ *
+ * This tests the fix for issue #292 (issue #1): Worktree up-to-date check
+ * misses shared refs changes.
+ */
+class WorktreeUpToDateFunctionalTest {
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    @Test
+    void testWorktreeDetectsTagAddedInMainRepo() {
+        // 1. Create main repo with initial commit
+        def mainRepoDir = temporaryFolder.newFolder("main-repo")
+        initGitRepo(mainRepoDir)
+        commitFile(mainRepoDir, "test.txt", "content", "Initial commit")
+
+        // 2. Create worktree
+        def worktreeDir = new File(temporaryFolder.root, "worktree")
+        createWorktree(mainRepoDir, worktreeDir, "feature-branch")
+
+        // 3. Setup gradle build in worktree
+        setupGradleBuild(worktreeDir)
+
+        // 4. First build - should be SUCCESS
+        def result1 = runGradle(worktreeDir, "generateGitProperties")
+        assertEquals("First build should succeed", TaskOutcome.SUCCESS, result1.task(":generateGitProperties").outcome)
+
+        // 5. Second build - should be UP-TO-DATE
+        def result2 = runGradle(worktreeDir, "generateGitProperties")
+        assertEquals("Second build should be UP-TO-DATE", TaskOutcome.UP_TO_DATE, result2.task(":generateGitProperties").outcome)
+
+        // 6. Add tag in main repo (this changes shared refs)
+        addTag(mainRepoDir, "v1.0.0")
+
+        // 7. Build in worktree - should be SUCCESS (not UP-TO-DATE)
+        // This verifies the fix: task detects the new tag in shared refs
+        def result3 = runGradle(worktreeDir, "generateGitProperties")
+        assertEquals("Build after tag should be SUCCESS (detect shared ref change)",
+            TaskOutcome.SUCCESS, result3.task(":generateGitProperties").outcome)
+
+        // 8. Verify git.properties was regenerated (file exists and was updated)
+        def gitProperties = new File(worktreeDir, "build/resources/main/git.properties")
+        assertTrue("git.properties should exist", gitProperties.exists())
+        // The core fix is verified: task detected the shared ref change and rebuilt.
+        // The closest tag property may or may not show v1.0.0 depending on commit distance.
+    }
+
+    @Test
+    void testNormalRepoStillWorksCorrectly() {
+        // Regression test: ensure non-worktree repos still work
+        def repoDir = temporaryFolder.newFolder("normal-repo")
+        initGitRepo(repoDir)
+        commitFile(repoDir, "test.txt", "content", "Initial commit")
+        setupGradleBuild(repoDir)
+
+        // First build
+        def result1 = runGradle(repoDir, "generateGitProperties")
+        assertEquals("First build should succeed", TaskOutcome.SUCCESS, result1.task(":generateGitProperties").outcome)
+
+        // Second build - UP-TO-DATE
+        def result2 = runGradle(repoDir, "generateGitProperties")
+        assertEquals("Second build should be UP-TO-DATE", TaskOutcome.UP_TO_DATE, result2.task(":generateGitProperties").outcome)
+
+        // Add tag
+        addTag(repoDir, "v1.0.0")
+
+        // Third build - should detect tag
+        def result3 = runGradle(repoDir, "generateGitProperties")
+        assertEquals("Build after tag should be SUCCESS", TaskOutcome.SUCCESS, result3.task(":generateGitProperties").outcome)
+    }
+
+    private void initGitRepo(File dir) {
+        exec(dir, "git", "init")
+        exec(dir, "git", "config", "user.email", "test@test.com")
+        exec(dir, "git", "config", "user.name", "Test")
+    }
+
+    private void commitFile(File dir, String filename, String content, String message) {
+        new File(dir, filename).text = content
+        exec(dir, "git", "add", filename)
+        exec(dir, "git", "commit", "-m", message)
+    }
+
+    private void createWorktree(File mainRepo, File worktreeDir, String branchName) {
+        exec(mainRepo, "git", "worktree", "add", worktreeDir.absolutePath, "-b", branchName)
+    }
+
+    private void addTag(File dir, String tagName) {
+        exec(dir, "git", "tag", tagName)
+    }
+
+    private void setupGradleBuild(File projectDir) {
+        new File(projectDir, "settings.gradle").text = "rootProject.name = 'test-project'"
+        new File(projectDir, "build.gradle").text = """
+            plugins {
+                id 'java'
+                id 'com.gorylenko.gradle-git-properties'
+            }
+        """
+    }
+
+    private def runGradle(File projectDir, String... args) {
+        return GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withArguments(args)
+            .withPluginClasspath()
+            .build()
+    }
+
+    private void exec(File workDir, String... command) {
+        def process = new ProcessBuilder(command)
+            .directory(workDir)
+            .redirectErrorStream(true)
+            .start()
+        def output = process.text
+        process.waitFor()
+        if (process.exitValue() != 0) {
+            throw new RuntimeException("Command failed: ${command.join(' ')}\n${output}")
+        }
+    }
+}

--- a/src/test/groovy/com/gorylenko/jgit/RepositoryFactoryTest.groovy
+++ b/src/test/groovy/com/gorylenko/jgit/RepositoryFactoryTest.groovy
@@ -72,4 +72,52 @@ class RepositoryFactoryTest {
             facade.close()
         }
     }
+
+    // ============================================
+    // Tests for getDirectoriesToWatch
+    // ============================================
+
+    @Test
+    void testGetDirectoriesToWatch_NullInput() {
+        def result = RepositoryFactory.getDirectoriesToWatch(null)
+        assertTrue("Null input should return empty list", result.isEmpty())
+    }
+
+    @Test
+    void testGetDirectoriesToWatch_NonExistent() {
+        def nonExistent = new File(temporaryFolder.root, "does-not-exist/.git")
+        def result = RepositoryFactory.getDirectoriesToWatch(nonExistent)
+        assertTrue("Non-existent file should return empty list", result.isEmpty())
+    }
+
+    @Test
+    void testGetDirectoriesToWatch_RegularRepo() {
+        def repoDir = temporaryFolder.newFolder("test-repo")
+        helper = JGitTestHelper.create(repoDir)
+        helper.commitFile("test.txt", "content", "Initial commit")
+
+        def dotGit = new File(repoDir, ".git")
+        def result = RepositoryFactory.getDirectoriesToWatch(dotGit)
+
+        assertEquals("Regular repo should return 1 directory", 1, result.size())
+        assertEquals("Should return .git directory", dotGit.canonicalFile, result[0].canonicalFile)
+    }
+
+    @Test
+    void testGetDirectoriesToWatch_Worktree() {
+        def mainRepoDir = temporaryFolder.newFolder("main-repo")
+        def worktreeDir = new File(temporaryFolder.root, "worktree")
+
+        helper = JGitTestHelper.create(mainRepoDir)
+        helper.commitFile("test.txt", "content", "Initial commit")
+        helper.createWorktree(worktreeDir, "feature-branch")
+
+        def dotGit = new File(worktreeDir, ".git")
+        def result = RepositoryFactory.getDirectoriesToWatch(dotGit)
+
+        assertEquals("Worktree should return 2 directories", 2, result.size())
+        // First should be worktree gitdir, second should be main git dir
+        def mainGitDir = new File(mainRepoDir, ".git")
+        assertTrue("Should include main git dir", result.any { it.canonicalPath == mainGitDir.canonicalPath })
+    }
 }


### PR DESCRIPTION
## Summary

- FileTree source for up-to-date checking now watches **both** worktree gitdir AND commondir
- Adds `RepositoryFactory.getDirectoriesToWatch()` to return appropriate directories
- Adds `packed-refs` to watch list (tags can be packed)

## Problem

In worktree builds, the FileTree source only watched `.git/worktrees/<name>/refs/**` which is typically empty. Shared refs (tags, branches) live in the main `.git/refs/**` directory, so changes like adding a tag didn't trigger rebuild.

**Before:** Adding tag in main repo → worktree build stays UP-TO-DATE (stale `git.closest.tag.name`)
**After:** Adding tag in main repo → worktree build is SUCCESS (detects shared ref change)

## Test plan

- [x] Unit tests for `getDirectoriesToWatch()` (null, non-existent, regular repo, worktree)
- [x] Functional test `WorktreeUpToDateFunctionalTest` verifying tag detection
- [x] All existing tests pass

Fixes #292

🤖 Generated with [Claude Code](https://claude.ai/code)