### PR TITLE
fix: upgrade Shadow plugin to 9.x and fix publishToMavenLocal (#291)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'maven-publish'
     id 'java-gradle-plugin'
     id "com.gradle.plugin-publish" version "1.2.1"
-    id "com.github.johnrengelman.shadow" version "8.1.1"
+    id "com.gradleup.shadow" version "9.0.2"
     id "com.gorylenko.gradle-git-properties" version "2.4.2"
 }
 
@@ -48,7 +48,7 @@ components.java.withVariantsFromConfiguration(configurations.runtimeElements) {
     skip()
 }
 
-version = "3.0.0"
+version = "3.0.1"
 group = "com.gorylenko.gradle-git-properties"
 
 gitProperties {
@@ -60,6 +60,7 @@ gitProperties {
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+    withSourcesJar()
 }
 
 tasks.withType(GroovyCompile) {
@@ -83,24 +84,7 @@ tasks.register("integrationTest", Test) {
     it.systemProperty "integration.plugin.path", tasks.shadowJar.outputs.getFiles().asPath // Pass java system property indicating integration plugin path
 }
 
-tasks.register("sourceJar", Jar) {
-    archiveClassifier.set("sources")
-    from sourceSets.main.resources, sourceSets.main.groovy
-
-    dependsOn tasks.named("classes")
-}
-
 publishing {
-
-    publications {
-
-        pluginJar(MavenPublication) {  publication ->
-
-            from project.shadow.component(publication)
-
-            artifact sourceJar
-        }
-    }
     // for testing: ./gradlew clean publishToMavenLocal
     repositories {
         mavenLocal()


### PR DESCRIPTION
## Summary

- Upgrade Shadow plugin from `com.github.johnrengelman.shadow:8.1.1` to `com.gradleup.shadow:9.0.2`
- Remove redundant `pluginJar` publication that used deprecated `shadow.component()` API
- Use `java.withSourcesJar()` instead of custom `sourceJar` task

## Root Cause

The `shadow.component(publication)` API iterates dependencies to generate POM entries. `gradleApi()` and `localGroovy()` have null group, causing NPE:

```
Cannot get property 'group' on null object
```

This API was deprecated in Shadow 8.x and removed in Shadow 9.x.

## Solution

Per Shadow plugin documentation, `com.gradle.plugin-publish` auto-detects Shadow and handles the `pluginMaven` publication automatically. The manual `pluginJar` publication was redundant.

## Verification

- `./gradlew publishToMavenLocal` succeeds
- `./gradlew publishPlugins --dry-run` succeeds  
- Published JAR is shadowed (3.7MB with relocated JGit)
- All bytecode references correctly relocated
- POM has no dependencies
- Unit and integration tests pass
- E2E consumer tests pass

Fixes #291