### PR TITLE
fix: update self-referencing plugin to 3.0.1, bump version to 3.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Add the plugin to your build file:
 **Groovy DSL** (`build.gradle`)
 ```groovy
 plugins {
-    id "com.gorylenko.gradle-git-properties" version "3.0.1"
+    id "com.gorylenko.gradle-git-properties" version "3.0.2"
 }
 ```
 
 **Kotlin DSL** (`build.gradle.kts`)
 ```kotlin
 plugins {
-    id("com.gorylenko.gradle-git-properties") version "3.0.1"
+    id("com.gorylenko.gradle-git-properties") version "3.0.2"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java-gradle-plugin'
     id "com.gradle.plugin-publish" version "1.2.1"
     id "com.gradleup.shadow" version "9.0.2"
-    id "com.gorylenko.gradle-git-properties" version "2.4.2"
+    id "com.gorylenko.gradle-git-properties" version "3.0.1"
 }
 
 repositories {
@@ -48,7 +48,7 @@ components.java.withVariantsFromConfiguration(configurations.runtimeElements) {
     skip()
 }
 
-version = "3.0.1"
+version = "3.0.2"
 group = "com.gorylenko.gradle-git-properties"
 
 gitProperties {


### PR DESCRIPTION
## Summary

- Update plugin version from 2.4.2 to 3.0.1 to enable worktree support for Docker builds
- Bump project version to 3.0.2
- Update README examples to 3.0.2

## Test plan

- [x] Verify build works from worktree/Docker environment
- [ ] CI passes

Fixes #299