### PR TITLE
fix: bump JGit to 7.6.0 to address CVE-2025-4949

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Add the plugin to your build file:
 **Groovy DSL** (`build.gradle`)
 ```groovy
 plugins {
-    id "com.gorylenko.gradle-git-properties" version "3.0.2"
+    id "com.gorylenko.gradle-git-properties" version "3.0.3"
 }
 ```
 
 **Kotlin DSL** (`build.gradle.kts`)
 ```kotlin
 plugins {
-    id("com.gorylenko.gradle-git-properties") version "3.0.2"
+    id("com.gorylenko.gradle-git-properties") version "3.0.3"
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,9 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven {
+        url 'https://repo.eclipse.org/content/repositories/jgit-releases/'
+    }
     // for debugging
     //maven {
     //    url 'https://repo.gradle.org/gradle/libs-releases-local/'
@@ -20,7 +23,7 @@ def integrationTest = sourceSets.create("integrationTest")
 dependencies {
     shadow gradleApi()
     shadow localGroovy()
-    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.1.0.202411261347-r'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit:7.6.0.202603022253-r'
     // for debugging
     //implementation 'org.gradle:gradle-language-jvm:5.6.2'
     //implementation 'org.gradle:gradle-language-java:5.6.2'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java-gradle-plugin'
     id "com.gradle.plugin-publish" version "1.2.1"
     id "com.gradleup.shadow" version "9.0.2"
-    id "com.gorylenko.gradle-git-properties" version "3.0.1"
+    id "com.gorylenko.gradle-git-properties" version "3.0.2"
 }
 
 repositories {
@@ -51,7 +51,7 @@ components.java.withVariantsFromConfiguration(configurations.runtimeElements) {
     skip()
 }
 
-version = "3.0.2"
+version = "3.0.3"
 group = "com.gorylenko.gradle-git-properties"
 
 gitProperties {


### PR DESCRIPTION
## Summary
- Update JGit from `7.1.0.202411261347-r` to `7.6.0.202603022253-r`
- Add Eclipse JGit releases repository (required since 7.6.0 isn't on Maven Central yet)

## Security
Fixes CVE-2025-4949 - XXE vulnerability in JGit's `ManifestParser` and `AmazonS3` classes.

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass

Closes #301